### PR TITLE
$capsule::params::certs_tar was not defined

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@ class capsule::params {
 
   # when not specified, we expect all in one installation
   $parent_fqdn                = $::fqdn
+  $certs_tar                  = undef
 
   # OAuth credentials
   # shares cached_data with the foreman module so they're the same


### PR DESCRIPTION
Caused issues when kafo tried to load default values.
