### PR TITLE
Moving certs into their own class to prevent defined type from being

### DIFF
--- a/manifests/certs.pp
+++ b/manifests/certs.pp
@@ -1,0 +1,8 @@
+# Handles certs for Capsules
+class capsule::certs {
+
+  certs::tar_extract { $capsule::certs_tar:
+    before => Class['certs']
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -109,14 +109,12 @@ class capsule (
 
   $foreman_url = "https://${parent_fqdn}"
 
-  if $certs_tar {
-    certs::tar_extract { $certs_tar:
-      before => Class['certs']
-    }
-  }
-
   if $register_in_foreman {
     validate_present($foreman_oauth_secret)
+  }
+
+  if $certs_tar {
+    class { 'capsule::certs': }
   }
 
   if $pulp {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,4 +35,7 @@ class capsule::params {
   $dns_forwareders               = $foreman_proxy::params::dns_forwarders
   $foreman_oauth_effective_user  = $foreman_proxy::params::oauth_effective_user
 
+  $register_in_foreman = false
+  $certs_tar = undef
+
 }


### PR DESCRIPTION
evaluated when the argument is undefined.
