### PR TITLE
Refs #6927 - remove check around pulp capsule prerequsites

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,7 +121,6 @@ class capsule (
   validate_present($capsule::parent_fqdn)
 
   if $pulp {
-    validate_pulp($pulp)
     validate_present($pulp_oauth_secret)
   }
 


### PR DESCRIPTION
The check was moved to the pre_validations hooks
