### PR TITLE
refs #7396 - set foreman ENC API version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -183,7 +183,8 @@ class capsule (
       server_storeconfigs_backend => false,
       server_dynamic_environments => true,
       server_environments_owner   => 'apache',
-      server_config_version       => ''
+      server_config_version       => '',
+      server_enc_api              => 'v2',
     }
   }
 


### PR DESCRIPTION
This change ensures that the foreman::puppetmaster module correctly
deploys /etc/puppet/node.rb, which is the external node classifier for
Foreman.
