### PR TITLE
Fixes #7643: Expose Puppet CA proxy option.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,11 @@
 # $puppetca::                       Use puppet ca
 #                                   type:boolean
 #
+# $puppet_ca_proxy::                The actual server that handles puppet CA.
+#                                   Setting this to anything non-empty causes
+#                                   the apache vhost to set up a proxy for all
+#                                   certificates pointing to the value.
+#
 # $tftp::                           Use TFTP
 #                                   type:boolean
 #
@@ -130,6 +135,7 @@ class capsule (
 
   $puppet                        = $capsule::params::puppet,
   $puppetca                      = $capsule::params::puppetca,
+  $puppet_ca_proxy               = $capsule::params::puppet_ca_proxy,
 
   $tftp                          = $capsule::params::tftp,
   $tftp_syslinux_root            = $capsule::params::tftp_syslinux_root,
@@ -256,6 +262,7 @@ class capsule (
       server_environments_owner   => 'apache',
       server_config_version       => '',
       server_enc_api              => 'v2',
+      server_ca_proxy             => $puppet_ca_proxy,
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class capsule::params {
 
   $puppet                        = false
   $puppetca                      = false
+  $puppet_ca_proxy               = ''
 
   $foreman_proxy_port            = '9090'
   $tftp                          = false


### PR DESCRIPTION
Exposing the puppet CA proxy option such that a capsule can serve
as a Puppet server but allow puppet agents to be proxied to a central
CA that is typically present on the Katello server itself.
