### PR TITLE
seperate parent_fqdn and foreman_fqdn

### DIFF
--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -1,7 +1,7 @@
 # Adds http reverse-proxy to parent conf
 class foreman_proxy_content::reverse_proxy (
   $path = '/',
-  $url  = "https://${foreman_proxy_content::parent_fqdn}/",
+  $url  = "${foreman_proxy_content::foreman_url}/",
   $port = $foreman_proxy_content::reverse_proxy_port,
 ) {
   include ::apache

--- a/templates/_pulp_gpg_proxy.erb
+++ b/templates/_pulp_gpg_proxy.erb
@@ -1,5 +1,5 @@
-  ProxyPass /katello/api/repositories/ https://<%= @parent_fqdn %>/katello/api/repositories/
+  ProxyPass /katello/api/repositories/ <%= @foreman_url %>/katello/api/repositories/
   <Location /katello/api/repositories/>
-    ProxyPassReverse https://<%= @parent_fqdn %>/
+    ProxyPassReverse <%= @foreman_url %>/
   </Location>
   SSLProxyEngine On


### PR DESCRIPTION
also cleanup a few var names to reflect what they actually mean

this is meant as a first step to integrate a pulp master into this module