### PR TITLE
[WIP] pulp master setup via foreman_proxy_content

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,8 @@
 #
 # $pulp_master::                        Whether the foreman_proxy_content should be identified as a pulp master server
 #
+# $pulp_master_standalone::             Whether the pulp master should manage httpd, only useable when having a pulp master without katello on the same server
+#
 # $pulp_admin_password::                Password for the Pulp admin user. It should be left blank so that a random password is generated
 #
 # $pulp_oauth_effective_user::          User to be used for Pulp REST interaction
@@ -25,6 +27,22 @@
 # $pulp_oauth_secret::                  OAuth secret to be used for Pulp REST interaction
 #
 # $pulp_max_speed::                     The maximum download speed per second for a Pulp task, such as a sync. (e.g. "4 Kb" (Uses SI KB), 4MB, or 1GB" )
+#
+# $pulp_consumers_crl::                 Certificate revocation list for consumers which are no valid (have had their client certs revoked)
+#
+# $pulp_max_tasks_per_child::           Number of tasks after which the worker is restarted and the memory it allocated is returned to the system
+#
+# $pulp_num_workers::                   Number of Pulp workers to use.
+#
+# $pulp_proxy_password::                Proxy password for authentication
+#
+# $pulp_proxy_port::                    Port the proxy is running on
+#
+# $pulp_proxy_url::                     URL of the proxy server
+#
+# $pulp_proxy_username::                Proxy username for authentication
+#
+# $pulp_puppet_wsgi_processes::         Number of WSGI processes to spawn for the puppet webapp
 #
 # $reverse_proxy::                      Add reverse proxy to the parent
 #
@@ -50,10 +68,12 @@
 #
 # $qpid_router_logging_path::           Directory for dispatch router logs
 #
+# $install_local_qpid::                 Should a local qpid server be installed
 class foreman_proxy_content (
   String[1] $parent_fqdn = $foreman_proxy_content::params::parent_fqdn,
   Optional[Stdlib::Absolutepath] $certs_tar = $foreman_proxy_content::params::certs_tar,
   Boolean $pulp_master = $foreman_proxy_content::params::pulp_master,
+  Boolean $pulp_master_standalone = $foreman_proxy_content::params::pulp_master_standalone,
   String $pulp_admin_password = $foreman_proxy_content::params::pulp_admin_password,
   String $pulp_oauth_effective_user = $foreman_proxy_content::params::pulp_oauth_effective_user,
   String $pulp_oauth_key = $foreman_proxy_content::params::pulp_oauth_key,
@@ -77,39 +97,47 @@ class foreman_proxy_content (
   String $qpid_router_logging_level = $foreman_proxy_content::params::qpid_router_logging_level,
   Stdlib::Absolutepath $qpid_router_logging_path = $foreman_proxy_content::params::qpid_router_logging_path,
   Boolean $enable_ostree = $foreman_proxy_content::params::enable_ostree,
+  Boolean $install_local_qpid = $foreman_proxy_content::params::install_local_qpid,
+  Optional[String] $pulp_consumers_crl = undef,
+  Optional[Integer] $pulp_max_tasks_per_child = undef,
+  Optional[Integer] $pulp_num_workers = undef,
+  Optional[String] $pulp_proxy_password = undef,
+  Optional[Integer] $pulp_proxy_port = undef,
+  Optional[String] $pulp_proxy_url = undef,
+  Optional[String] $pulp_proxy_username = undef,
+  Optional[String] $pulp_puppet_wsgi_processes = undef,
 ) inherits foreman_proxy_content::params {
   include ::certs
   include ::foreman_proxy
   include ::foreman_proxy::plugin::pulp
 
   $pulp_node = $::foreman_proxy::plugin::pulp::pulpnode_enabled
-  if $pulp_node {
+  if $pulp_node and $pulp_master {
+    fail('You cannot install pulp_node and pulp_master on same server')
+  }
+
+  if $pulp_node or $pulp_master {
     assert_type(String[1], $pulp_oauth_secret)
   }
 
   $foreman_proxy_fqdn = $::fqdn
   $foreman_url = $::foreman_proxy::foreman_base_url
-  $setup_reverse_proxy = $pulp_node or $reverse_proxy
+  $setup_reverse_proxy = $pulp_node or $reverse_proxy or $pulp_master_standalone
+  $create_pub_dir = $pulp_node or $reverse_proxy or $pulp_master_standalone
+  $install_pulp = $pulp_node or $pulp_master
+  $manage_httpd = $pulp_node or $pulp_master_standalone
 
   $rhsm_port = $setup_reverse_proxy ? {
     true  => $reverse_proxy_port,
     false => '443'
   }
 
-  package{ ['katello-debug', 'katello-client-bootstrap']:
-    ensure => installed,
-  }
-
-  class { '::certs::foreman_proxy':
-    hostname => $foreman_proxy_fqdn,
-    require  => Class['certs'],
-    notify   => Service['foreman-proxy'],
-  }
+  include ::certs::foreman_proxy
+  Class['::certs::foreman_proxy'] ~> Service['foreman-proxy']
 
   class { '::certs::katello':
     deployment_url => $rhsm_url,
     rhsm_port      => $rhsm_port,
-    require        => Class['certs'],
   }
 
   if $setup_reverse_proxy {
@@ -142,9 +170,6 @@ class foreman_proxy_content (
   }
 
   if $pulp_node {
-    include ::apache
-    $apache_version = $::apache::apache_version
-
     file {'/etc/httpd/conf.d/pulp_nodes.conf':
       ensure  => file,
       content => template('foreman_proxy_content/pulp_nodes.conf.erb'),
@@ -153,6 +178,14 @@ class foreman_proxy_content (
       mode    => '0644',
     }
 
+    $default_password =  $pulp_admin_password
+  }
+
+  if $create_pub_dir {
+    package { 'katello-client-bootstrap':
+      ensure => installed,
+    }
+    include ::apache
     apache::vhost { 'foreman_proxy_content':
       servername          => $foreman_proxy_fqdn,
       port                => 80,
@@ -162,49 +195,88 @@ class foreman_proxy_content (
       additional_includes => ['/etc/pulp/vhosts80/*.conf'],
       custom_fragment     => template('foreman_proxy_content/httpd_pub.erb'),
     }
+  }
 
-    class { '::certs::qpid':
-      require => Class['certs'],
-    }
-    ~> class { '::qpid':
+  # current behaviour always install qpid with a pulp_node unless you explicitly disable local qpid
+  # pulp_master without standalone already has qpid through katello install
+  if $install_local_qpid and ( $pulp_node or $pulp_master_standalone ) {
+    include ::certs::qpid
+    class { '::qpid':
       ssl                    => true,
       ssl_cert_db            => $::certs::nss_db_dir,
       ssl_cert_password_file => $::certs::qpid::nss_db_password_file,
       ssl_cert_name          => 'broker',
       interface              => 'lo',
+      subscribe              => Class['::certs::qpid'],
+    }
+  }
+
+  if $install_pulp {
+    include ::certs::qpid_client
+
+    if $manage_httpd {
+      $ca_cert = $::certs::ca_cert
+      $https_cert = $certs::apache::apache_cert
+      $https_key = $certs::apache::apache_key
+    } else {
+      $ca_cert = undef
+      $https_cert = undef
+      $https_key = undef
     }
 
-    class { '::certs::qpid_client':
-      require => Class['certs'],
+    if $pulp_node {
+      $node_oauth_effective_user = $pulp_oauth_effective_user
+      $node_oauth_key            = $pulp_oauth_key
+      $node_oauth_secret         = $pulp_oauth_secret
+      $node_server_ca_cert       = $certs::pulp_server_ca_cert
+    } else {
+      $node_oauth_effective_user = undef
+      $node_oauth_key            = undef
+      $node_oauth_secret         = undef
+      $node_server_ca_cert       = undef
     }
-    ~> class { '::pulp':
-      enable_rpm                => true,
-      enable_puppet             => true,
+
+
+
+    class { '::pulp':
+      broker_url                => "qpid://${qpid_router_broker_addr}:${qpid_router_broker_port}",
+      broker_use_ssl            => true,
+      ca_cert                   => $ca_cert,
+      consumers_crl             => $pulp_consumers_crl,
+      default_password          => $default_password,
       enable_docker             => true,
+      enable_katello            => $pulp_master,
       enable_ostree             => $enable_ostree,
-      default_password          => $pulp_admin_password,
+      enable_parent_node        => false,
+      enable_puppet             => true,
+      enable_rpm                => true,
+      https_cert                => $https_cert,
+      https_key                 => $https_key,
+      manage_broker             => false,
+      manage_httpd              => $manage_httpd,
+      manage_plugins_httpd      => true,
+      manage_squid              => true,
+      max_tasks_per_child       => $pulp_max_tasks_per_child,
+      messaging_auth_enabled    => false,
+      messaging_ca_cert         => $certs::ca_cert,
+      messaging_client_cert     => $certs::qpid_client::messaging_client_cert,
+      messaging_transport       => 'qpid',
+      messaging_url             => "ssl://${qpid_router_broker_addr}:${qpid_router_broker_port}",
+      node_oauth_effective_user => $node_oauth_effective_user,
+      node_oauth_key            => $node_oauth_key,
+      node_oauth_secret         => $node_oauth_secret,
+      node_server_ca_cert       => $node_server_ca_cert,
+      num_workers               => $pulp_num_workers,
       oauth_enabled             => true,
       oauth_key                 => $pulp_oauth_key,
       oauth_secret              => $pulp_oauth_secret,
-      messaging_transport       => 'qpid',
-      messaging_auth_enabled    => false,
-      messaging_ca_cert         => $certs::ca_cert,
-      messaging_client_cert     => $certs::messaging_client_cert,
-      messaging_url             => "ssl://${qpid_router_broker_addr}:${qpid_router_broker_port}",
-      broker_url                => "qpid://${qpid_router_broker_addr}:${qpid_router_broker_port}",
-      broker_use_ssl            => true,
-      manage_broker             => false,
-      manage_httpd              => true,
-      manage_plugins_httpd      => true,
-      manage_squid              => true,
+      proxy_password            => $pulp_proxy_password,
+      proxy_port                => $pulp_proxy_port,
+      proxy_url                 => $pulp_proxy_url,
+      proxy_username            => $pulp_proxy_username,
+      puppet_wsgi_processes     => $pulp_puppet_wsgi_processes,
       repo_auth                 => true,
-      node_oauth_effective_user => $pulp_oauth_effective_user,
-      node_oauth_key            => $pulp_oauth_key,
-      node_oauth_secret         => $pulp_oauth_secret,
-      node_server_ca_cert       => $certs::pulp_server_ca_cert,
-      https_cert                => $certs::apache::apache_cert,
-      https_key                 => $certs::apache::apache_key,
-      ca_cert                   => $certs::ca_cert,
+      subscribe                 => Class['certs::qpid_client'],
       yum_max_speed             => $pulp_max_speed,
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,12 +13,14 @@ class foreman_proxy_content::params {
   $puppet                    = true
 
   $pulp_master               = false
+  $pulp_master_standalone    = false
   $pulp_admin_password       = cache_data('foreman_cache_data', 'pulp_node_admin_password', random_password(32))
   $pulp_oauth_effective_user = 'admin'
   $pulp_oauth_key            = 'katello'
   $pulp_oauth_secret         = undef
   $pulp_max_speed            = undef
 
+  $install_local_qpid        = true
   $qpid_router               = true
   $qpid_router_hub_addr      = '0.0.0.0'
   $qpid_router_agent_addr    = '0.0.0.0'

--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -1,7 +1,7 @@
 # Adds http reverse-proxy to parent conf
 class foreman_proxy_content::reverse_proxy (
   $path = '/',
-  $url  = "https://${foreman_proxy_content::parent_fqdn}/",
+  $url  = "${foreman_proxy_content::foreman_url}/",
   $port = $foreman_proxy_content::reverse_proxy_port,
 ) {
   include ::apache

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -10,8 +10,7 @@ describe 'foreman_proxy_content' do
 	  end
 
 
-      it { should contain_package('katello-debug') }
-      it { should contain_package('katello-client-bootstrap') }
+      it { should contain_class('certs::katello') }
 
       context 'with pulp' do
         let(:params) do
@@ -30,6 +29,7 @@ describe 'foreman_proxy_content' do
         it { should contain_class('pulp').with(:oauth_secret => 'mysecret') }
         it { should_not contain_class('foreman_proxy_content::dispatch_router') }
 
+        it { should contain_package('katello-client-bootstrap') }
         it { should contain_pulp__apache__fragment('gpg_key_proxy').with({
           :ssl_content => %r{ProxyPass /katello/api/repositories/}} ) }
       end

--- a/templates/_pulp_gpg_proxy.erb
+++ b/templates/_pulp_gpg_proxy.erb
@@ -1,5 +1,5 @@
-  ProxyPass /katello/api/repositories/ https://<%= @parent_fqdn %>/katello/api/repositories/
+  ProxyPass /katello/api/repositories/ <%= @foreman_url %>/katello/api/repositories/
   <Location /katello/api/repositories/>
-    ProxyPassReverse https://<%= @parent_fqdn %>/
+    ProxyPassReverse <%= @foreman_url %>/
   </Location>
   SSLProxyEngine On

--- a/templates/httpd_pub.erb
+++ b/templates/httpd_pub.erb
@@ -5,10 +5,6 @@ alias /pub /var/www/html/pub
     PassengerEnabled off
   </IfModule>
   Options +FollowSymLinks +Indexes
-<%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
   Require all granted
-<% else -%>
-  Allow from all
-<% end -%>
 
 </Location>


### PR DESCRIPTION
this includes #132 
it is supposed to be the second step towards installing pulp masters via foreman_proxy_content. This should work for pulp master (with katello application and without) and pulp nodes.