### PR TITLE
introduce manage broker parameter

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -1,0 +1,19 @@
+# Manages a standalone qpid broker for pulp
+# E.g. in Katello, the master pulp instance uses
+# Katello's main qpid message broker.
+# This can be used for a separate pulp instance
+# that also needs a broker of its own.
+class foreman_proxy_content::broker (
+  String $interface = 'lo',
+) {
+  include ::certs::qpid
+
+  class { '::qpid':
+    ssl                    => true,
+    ssl_cert_db            => $::certs::nss_db_dir,
+    ssl_cert_password_file => $::certs::qpid::nss_db_password_file,
+    ssl_cert_name          => 'broker',
+    interface              => $interface,
+    subscribe              => Class['certs', 'certs::qpid'],
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,4 +30,6 @@ class foreman_proxy_content::params {
   $qpid_router_logging_path  = '/var/log/qdrouterd'
 
   $enable_ostree             = false
+
+  $manage_broker             = true
 }

--- a/spec/classes/foreman_proxy_content__broker_spec.rb
+++ b/spec/classes/foreman_proxy_content__broker_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'foreman_proxy_content::broker' do
+  on_os_under_test.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      it { is_expected.to compile.with_all_deps }
+    end
+  end
+end


### PR DESCRIPTION
This extracts the management of the qpid message broker for a not-master pulp instance (pulp node) to a separate class. In addition, a parameter was added if a user does not want puppet or this module to manage it.