### PR TITLE
introduce rhsm_hostname parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,7 +30,9 @@
 #
 # $reverse_proxy_port::                 Reverse proxy listening port
 #
-# $rhsm_url::                           The URL that the RHSM API is rooted at
+# $rhsm_hostname::                      The hostname that the RHSM API is rooted at
+#
+# $rhsm_url::                           The URL path that the RHSM API is rooted at
 #
 # $qpid_router::                        Configure qpid dispatch router
 #
@@ -65,6 +67,7 @@ class foreman_proxy_content (
   Boolean $reverse_proxy = $foreman_proxy_content::params::reverse_proxy,
   Integer[0, 65535] $reverse_proxy_port = $foreman_proxy_content::params::reverse_proxy_port,
 
+  Optional[String] $rhsm_hostname = $foreman_proxy_content::params::rhsm_hostname,
   String $rhsm_url = $foreman_proxy_content::params::rhsm_url,
 
   Boolean $qpid_router = $foreman_proxy_content::params::qpid_router,
@@ -107,6 +110,7 @@ class foreman_proxy_content (
   }
 
   class { '::certs::katello':
+    hostname       => $rhsm_hostname,
     deployment_url => $rhsm_url,
     rhsm_port      => $rhsm_port,
     require        => Class['certs'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class foreman_proxy_content::params {
   $reverse_proxy_port = 8443
 
   $certs_tar = undef
+  $rhsm_hostname = undef
   $rhsm_url = '/rhsm'
 
   $puppet                    = true

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -32,6 +32,22 @@ describe 'foreman_proxy_content' do
         it { should contain_pulp__apache__fragment('gpg_key_proxy').with({
           :ssl_content => %r{ProxyPass /katello/api/repositories/}} ) }
       end
+
+      context 'with rhsm_hostname and rhsm_url' do
+        let(:params) do
+          {
+            :rhsm_hostname => 'katello.example.com',
+            :rhsm_url      => '/abc/rhsm'
+          }
+
+          it do
+            should contain_class('certs::katello').with(
+              :hostname => 'katello.example.com',
+              :deployment_url => '/abc/rhsm'
+            )
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This adds a parameter `rhsm_hostname` that allows overwriting the hostname that is configured into the client cert rpm.