### PR TITLE
Only set up puppet integration if needed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -259,11 +259,12 @@ class foreman_proxy_content (
     # parameter values from the main ::certs class.  Kafo can't handle that case, so
     # it remains here for now.
     include ::puppet
-    include ::puppet::server
-    class { '::certs::puppet':
-      hostname => $foreman_proxy_fqdn,
-      require  => Class['certs'],
-      notify   => Class['puppet'],
+    if $::puppet::server and $::puppet::server::foreman {
+      class { '::certs::puppet':
+        hostname => $foreman_proxy_fqdn,
+        require  => Class['certs'],
+        before   => Class['puppet'],
+      }
     }
   }
 


### PR DESCRIPTION
This still isn't quite perfect, but right now I can't think of a better way to correctly determine if puppet integration is actually needed.  Ideally we would get rid of the $puppet parameter but then we need to resort to defined('puppet') and that's compile order dependent.

This does mean at worst we pull in the client and not the server.

We can also change the notify to a before because the integration is just scripts that read files every run. There is no daemon that caches it.