### PR TITLE
Remove redundant symlink

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -17,5 +17,3 @@ fixtures:
     trusted_ca:    "https://github.com/evenup/evenup-trusted_ca.git"
     squid3:        "https://github.com/thias/puppet-squid3.git"
     systemd:       "https://github.com/camptocamp/puppet-systemd.git"
-  symlinks:
-    foreman_proxy_content: "#{source_dir}"


### PR DESCRIPTION
With recent versions of puppetlabs_spec_helper this is done automatically