### PR TITLE
Remove certs_tar parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,8 +18,6 @@
 #
 # $enable_deb::                         Enable debian content plugin
 #
-# $certs_tar::                          Path to a tar with certs for the node
-#
 # === Advanced parameters:
 #
 # $puppet::                             Enable puppet
@@ -88,7 +86,6 @@
 #
 class foreman_proxy_content (
   String[1] $parent_fqdn = $foreman_proxy_content::params::parent_fqdn,
-  Optional[Stdlib::Absolutepath] $certs_tar = $foreman_proxy_content::params::certs_tar,
   Boolean $pulp_master = $foreman_proxy_content::params::pulp_master,
   String $pulp_admin_password = $foreman_proxy_content::params::pulp_admin_password,
   Optional[String] $pulp_max_speed = $foreman_proxy_content::params::pulp_max_speed,
@@ -265,12 +262,6 @@ class foreman_proxy_content (
         require  => Class['certs'],
         before   => Class['puppet'],
       }
-    }
-  }
-
-  if $certs_tar {
-    certs::tar_extract { $certs_tar:
-      before => Class['certs'],
     }
   }
 }


### PR DESCRIPTION
This relies on [puppet-certs accepting the parameter](https://github.com/theforeman/puppet-certs/pull/215)