### PR TITLE
Correct chaining on puppet master integration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -262,8 +262,7 @@ class foreman_proxy_content (
     if $::puppet::server and $::puppet::server::foreman {
       class { '::certs::puppet':
         hostname => $foreman_proxy_fqdn,
-        require  => Class['certs'],
-        before   => Class['puppet'],
+        before   => Class['foreman::puppetmaster'],
       }
     }
   }

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -53,6 +53,36 @@ describe 'foreman_proxy_content' do
             .with_deployment_url('/abc/rhsm')
         end
       end
+
+      context 'with puppet' do
+        let(:params) do
+          {
+            puppet: true,
+          }
+        end
+
+        describe 'with puppet server enabled' do
+          let(:pre_condition) do
+            <<-PUPPET
+            class { 'puppet':
+              server         => true,
+              server_foreman => true,
+            }
+            PUPPET
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it do
+            is_expected.to contain_class('certs::puppet')
+              .that_comes_before('Class[foreman::puppetmaster]')
+          end
+        end
+
+        describe 'with puppet server disabled' do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.not_to contain_class('certs::puppet') }
+        end
+      end
     end
   end
 end

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -5,47 +5,52 @@ describe 'foreman_proxy_content' do
     context "on #{os}" do
       let(:facts) { facts }
 
-      let :pre_condition do
-        "include foreman_proxy"
-	  end
-
-
-      it { should contain_package('katello-debug') }
+      context 'without parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_package('katello-debug') }
+      end
 
       context 'with pulp' do
         let(:params) do
           {
-            :qpid_router       => false
+            qpid_router: false
           }
         end
 
         let(:pre_condition) do
-          "include foreman_proxy
-          class {'foreman_proxy::plugin::pulp': pulpnode_enabled => true}"
+          <<-PUPPET
+          include foreman_proxy
+          class { 'foreman_proxy::plugin::pulp':
+            pulpnode_enabled => true,
+          }
+          PUPPET
         end
 
-        it { should contain_class('pulp').with(:manage_squid => true) }
-        it { should_not contain_class('foreman_proxy_content::dispatch_router') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('pulp').with(manage_squid: true) }
+        it { is_expected.not_to contain_class('foreman_proxy_content::dispatch_router') }
 
-        it { should contain_class('foreman_proxy_content::pub_dir') }
+        it { is_expected.to contain_class('foreman_proxy_content::pub_dir') }
 
-        it { should contain_pulp__apache__fragment('gpg_key_proxy').with({
-          :ssl_content => %r{ProxyPass /katello/api/repositories/ https://foo\.example\.com/katello/api/repositories/}} ) }
+        it do
+          is_expected.to contain_pulp__apache__fragment('gpg_key_proxy')
+            .with_ssl_content(%r{ProxyPass /katello/api/repositories/ https://foo\.example\.com/katello/api/repositories/})
+        end
       end
 
       context 'with rhsm_hostname and rhsm_url' do
         let(:params) do
           {
-            :rhsm_hostname => 'katello.example.com',
-            :rhsm_url      => '/abc/rhsm'
+            rhsm_hostname: 'katello.example.com',
+            rhsm_url: '/abc/rhsm'
           }
+        end
 
-          it do
-            should contain_class('certs::katello').with(
-              :hostname => 'katello.example.com',
-              :deployment_url => '/abc/rhsm'
-            )
-          end
+        it { is_expected.to compile.with_all_deps }
+        it do
+          is_expected.to contain_class('certs::katello')
+            .with_hostname('katello.example.com')
+            .with_deployment_url('/abc/rhsm')
         end
       end
     end


### PR DESCRIPTION
The certs::puppet class inherits from certs so that require is redundant.

We must also chain it to foreman::puppetmaster because puppet now contains the entire installation. However, it's also provides the User[puppet] which is the owner of the file. This creates a dependency cycle. By setting up the cert foreman::puppetmaster uses before the actual class is used, we avoid this problem and guarantee the ENC integration is still set up before the puppet master starts.

While we're at it, we also fix the style of foreman_proxy_content_spec.rb but in a separate commit for easier reviewing.