### PR TITLE
Allow docker pull on $HOSTNAME

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -249,6 +249,10 @@ class foreman_proxy_content (
     pulp::apache::fragment{'gpg_key_proxy':
       ssl_content => template('foreman_proxy_content/_pulp_gpg_proxy.erb', 'foreman_proxy_content/httpd_pub.erb'),
     }
+
+    pulp::apache::fragment{'redirect_crane':
+      ssl_content => template('foreman_proxy_content/redirect_crane.erb'),
+    }
   }
 
   if $puppet {

--- a/templates/redirect_crane.erb
+++ b/templates/redirect_crane.erb
@@ -1,0 +1,3 @@
+RewriteEngine on
+RewriteRule ^/v1/(.*)$ https://%{HTTP_HOST}:5000/v1/$1 [R=301,L]
+RewriteRule ^/v2/(.*)$ https://%{HTTP_HOST}:5000/v2/$1 [R=301,L]


### PR DESCRIPTION
This is to allow docker pull against $HOSTNAME without having to
specify port in the registry declaration.