### PR TITLE
Fixes #26088 - don't set ssl_proxy_machine_cert for rhsm proxy

### DIFF
--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -20,7 +20,6 @@ class foreman_proxy_content::reverse_proxy (
     ssl                    => true,
     ssl_proxyengine        => true,
     ssl_proxy_ca_cert      => $certs::ca_cert,
-    ssl_proxy_machine_cert => $certs::foreman_proxy::foreman_proxy_ssl_client_bundle,
     ssl_cert               => $certs::apache::apache_cert,
     ssl_key                => $certs::apache::apache_key,
     ssl_chain              => $certs::katello_server_ca_cert,

--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -12,30 +12,30 @@ class foreman_proxy_content::reverse_proxy (
   Class['certs', 'certs::ca', 'certs::apache', 'certs::foreman_proxy'] ~> Class['apache::service']
 
   apache::vhost { 'katello-reverse-proxy':
-    servername             => $foreman_proxy_content::foreman_proxy_fqdn,
-    port                   => $port,
-    docroot                => '/var/www/',
-    priority               => '28',
-    ssl_options            => ['+StdEnvVars', '+ExportCertData', '+FakeBasicAuth'],
-    ssl                    => true,
-    ssl_proxyengine        => true,
-    ssl_proxy_ca_cert      => $certs::ca_cert,
-    ssl_cert               => $certs::apache::apache_cert,
-    ssl_key                => $certs::apache::apache_key,
-    ssl_chain              => $certs::katello_server_ca_cert,
-    ssl_ca                 => $certs::ca_cert,
-    ssl_verify_client      => 'optional',
-    ssl_verify_depth       => 10,
-    ssl_protocol           => $ssl_protocol,
-    request_headers        => ['set X_RHSM_SSL_CLIENT_CERT "%{SSL_CLIENT_CERT}s"'],
-    proxy_pass             => [
+    servername        => $foreman_proxy_content::foreman_proxy_fqdn,
+    port              => $port,
+    docroot           => '/var/www/',
+    priority          => '28',
+    ssl_options       => ['+StdEnvVars', '+ExportCertData', '+FakeBasicAuth'],
+    ssl               => true,
+    ssl_proxyengine   => true,
+    ssl_proxy_ca_cert => $certs::ca_cert,
+    ssl_cert          => $certs::apache::apache_cert,
+    ssl_key           => $certs::apache::apache_key,
+    ssl_chain         => $certs::katello_server_ca_cert,
+    ssl_ca            => $certs::ca_cert,
+    ssl_verify_client => 'optional',
+    ssl_verify_depth  => 10,
+    ssl_protocol      => $ssl_protocol,
+    request_headers   => ['set X_RHSM_SSL_CLIENT_CERT "%{SSL_CLIENT_CERT}s"'],
+    proxy_pass        => [
       {
         'path'         => $path,
         'url'          => $url,
         'reverse_urls' => [$path, $url]
       }
     ],
-    error_documents        => [
+    error_documents   => [
       {
         'error_code' => '500',
         'document'   => '\'{"displayMessage": "Internal error, contact administrator", "errors": ["Internal error, contact administrator"], "status": "500" }\''


### PR DESCRIPTION
It seems SSLProxyMachineCertificateFile option supports only pkcs1
format (containing BEGIN RSA PRIVATE KEY), while it's not possible to use
this kind of keys in FIPS mode. The implication of this is we can't use
this directive in FIPS enabled environment.

Additionally, I don't see any reason to use this directive in the first
place so it seems it should be safe to remove. Please speak up with if you can think of one.

What I've tried is to comment out this setting and doing this from registered host worked just fine:

curl --cert /etc/pki/consumer/cert.pem --key /etc/pki/consumer/key.pem -k https://mycapsule.example.com:8443/rhsm/consumers/$(subscription-manager identity | head -n1 | grep -o '\S*$')