### PR TITLE
Further namespace extlib functions

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,7 +41,7 @@ class foreman_proxy_content::params {
   $qpid_router_ssl_protocols = undef
   $qpid_router_sasl_mech   = 'PLAIN'
   $qpid_router_sasl_username = 'katello_agent'
-  $qpid_router_sasl_password = cache_data('foreman_cache_data', 'qpid_router_sasl_password', random_password(16))
+  $qpid_router_sasl_password = extlib::cache_data('foreman_cache_data', 'qpid_router_sasl_password', extlib::random_password(16))
 
   $enable_ostree             = false
   $enable_yum                = true


### PR DESCRIPTION
7e9f683dbdc980a1790beb5b07db368b4c8ab909 moved over the first call but omitted the second one. This completes the transition of moving away from deprecated functions.