### PR TITLE
Allow customization of pub dir on foreman proxy server

### DIFF
--- a/manifests/pub_dir.pp
+++ b/manifests/pub_dir.pp
@@ -3,6 +3,7 @@
 # for download
 class foreman_proxy_content::pub_dir (
   String $servername = $facts['fqdn'],
+  String $pub_dir_options = '+FollowSymLinks +Indexes',
 ) {
   include foreman_proxy_content
   include apache

--- a/templates/httpd_pub.erb
+++ b/templates/httpd_pub.erb
@@ -4,6 +4,6 @@ alias /pub /var/www/html/pub
   <IfModule mod_passenger.c>
     PassengerEnabled off
   </IfModule>
-  Options +FollowSymLinks +Indexes
+  Options <%= @pub_dir_options %>
   Require all granted
 </Location>


### PR DESCRIPTION
We have a hardcoded value `Options` for `Location /pub` on the foreman proxy node 

https://github.com/theforeman/puppet-foreman_proxy_content/blob/7c479d473cd4e4a54483e9495bf73c466cfce2b7/templates/httpd_pub.erb#L7

We should allow over-riding this value through hiera because some users don't like to expose `/pub` per security guidelines.

~~~
# vi /etc/foreman-installer/custom-hiera.yaml
foreman_proxy_content::pub_dir::pub_dir_options: "+FollowSymLinks"
~~~