### PR TITLE
Move the certs::apache definition into reverse_proxy

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,7 +165,7 @@ class foreman_proxy_content (
     require        => Class['certs'],
   }
 
-  if $pulp or $reverse_proxy_real {
+  if $reverse_proxy_real {
     class { 'foreman_proxy_content::reverse_proxy':
       path         => '/',
       url          => "${foreman_url}/",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,16 +166,11 @@ class foreman_proxy_content (
   }
 
   if $pulp or $reverse_proxy_real {
-    class { 'certs::apache':
-      hostname => $foreman_proxy_fqdn,
-      require  => Class['certs'],
-    }
-    ~> class { 'foreman_proxy_content::reverse_proxy':
+    class { 'foreman_proxy_content::reverse_proxy':
       path         => '/',
       url          => "${foreman_url}/",
       servername   => $foreman_proxy_fqdn,
       port         => $reverse_proxy_port,
-      subscribe    => Class['certs::foreman_proxy'],
       ssl_protocol => $ssl_protocol,
     }
   }

--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -24,8 +24,11 @@ class foreman_proxy_content::reverse_proxy (
   Hash[String, String] $proxy_pass_params = {},
 ) {
   include apache
-  include certs::apache
   include certs::foreman_proxy
+
+  class { 'certs::apache':
+    hostname => $servername,
+  }
 
   Class['certs', 'certs::ca', 'certs::apache', 'certs::foreman_proxy'] ~> Class['apache::service']
 


### PR DESCRIPTION
It was already included and internally already had the correct triggers. This simplifies the code.