### PR TITLE
Derive $pulp_master variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,17 +165,18 @@ class foreman_proxy_content (
     require        => Class['certs'],
   }
 
-  if $pulp or $reverse_proxy_real {
+  if $pulp_master or $reverse_proxy_real {
     class { 'certs::apache':
       hostname => $foreman_proxy_fqdn,
-      require  => Class['certs'],
     }
-    ~> class { 'foreman_proxy_content::reverse_proxy':
+  }
+
+  if $reverse_proxy_real {
+    class { 'foreman_proxy_content::reverse_proxy':
       path         => '/',
       url          => "${foreman_url}/",
       servername   => $foreman_proxy_fqdn,
       port         => $reverse_proxy_port,
-      subscribe    => Class['certs::foreman_proxy'],
       ssl_protocol => $ssl_protocol,
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,8 +22,6 @@
 #
 # $puppet::                             Enable puppet
 #
-# $pulp_master::                        Whether the foreman_proxy_content should be identified as a pulp master server
-#
 # $pulp_admin_password::                Password for the Pulp admin user. It should be left blank so that a random password is generated
 #
 # $pulp_max_speed::                     The maximum download speed per second for a Pulp task, such as a sync. (e.g. "4 Kb" (Uses SI KB), 4MB, or 1GB" )
@@ -90,7 +88,6 @@
 #
 class foreman_proxy_content (
   String[1] $parent_fqdn = $foreman_proxy_content::params::parent_fqdn,
-  Boolean $pulp_master = $foreman_proxy_content::params::pulp_master,
   String $pulp_admin_password = $foreman_proxy_content::params::pulp_admin_password,
   Optional[String] $pulp_max_speed = $foreman_proxy_content::params::pulp_max_speed,
   Optional[Integer[1]] $pulp_num_workers = $foreman_proxy_content::params::pulp_num_workers,
@@ -139,6 +136,7 @@ class foreman_proxy_content (
   include foreman_proxy
   include foreman_proxy::plugin::pulp
 
+  $pulp_master = $foreman_proxy::plugin::pulp::enabled
   $pulp = $foreman_proxy::plugin::pulp::pulpnode_enabled
 
   $foreman_proxy_fqdn = $facts['fqdn']
@@ -183,9 +181,7 @@ class foreman_proxy_content (
 
   if $pulp_master or $pulp {
     if $qpid_router {
-      class { 'foreman_proxy_content::dispatch_router':
-        require => Class['pulp'],
-      }
+      contain foreman_proxy_content::dispatch_router
     }
 
     class { 'pulp::crane':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,7 +15,6 @@ class foreman_proxy_content::params {
 
   $puppet                    = true
 
-  $pulp_master               = false
   $pulp_admin_password       = extlib::cache_data('foreman_cache_data', 'pulp_node_admin_password', extlib::random_password(32))
   $pulp_max_speed            = undef
   $pulp_num_workers          = undef

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -21,6 +21,7 @@ describe 'foreman_proxy_content' do
           <<-PUPPET
           include foreman_proxy
           class { 'foreman_proxy::plugin::pulp':
+            enabled          => false,
             pulpnode_enabled => true,
           }
           PUPPET


### PR DESCRIPTION
We can know whether we're a pulp master depending on the proxy setting. There's no need to duplicate it.