### PR TITLE
Make dispatch router standalone classes

### DIFF
--- a/manifests/dispatch_router/connector.pp
+++ b/manifests/dispatch_router/connector.pp
@@ -1,0 +1,41 @@
+# @summary Configure qpid router to connect to a hub
+#
+# @param host
+#   The host to connect to
+# @param port
+#   The port to connect to
+#
+class foreman_proxy_content::dispatch_router::connector (
+  Stdlib::Host $host,
+  Stdlib::Port $port = 5646,
+) {
+  include foreman_proxy_content::dispatch_router
+
+  qpid::router::connector { 'hub':
+    host         => $host,
+    port         => $port,
+    ssl_profile  => 'client',
+    role         => 'inter-router',
+    idle_timeout => 0,
+  }
+
+  qpid::router::link_route { 'hub-pulp-route-in':
+    prefix    => 'pulp.',
+    direction => 'in',
+  }
+
+  qpid::router::link_route { 'hub-pulp-route-out':
+    prefix    => 'pulp.',
+    direction => 'out',
+  }
+
+  qpid::router::link_route { 'hub-qmf-route-in':
+    prefix    => 'qmf.',
+    direction => 'in',
+  }
+
+  qpid::router::link_route { 'hub-qmf-route-out':
+    prefix    => 'qmf.',
+    direction => 'out',
+  }
+}

--- a/manifests/dispatch_router/hub.pp
+++ b/manifests/dispatch_router/hub.pp
@@ -1,0 +1,76 @@
+# @summary Configure qpid router to listen as a hub
+#
+# @param hub_addr
+#   Address to listen on
+#
+# @param hub_port
+#   Port to listen on
+#
+# @param broker_addr
+#   Address of qpidd broker to connect to
+#
+# @param broker_port
+#   Port of qpidd broker to connect to
+#
+# @param sasl_mech
+#   SASL mechanism to be used from router to broker
+#
+# @param sasl_username
+#   SASL username to be used from router to broker
+#
+# @param sasl_password
+#   SASL password to be used from router to broker
+class foreman_proxy_content::dispatch_router::hub (
+  Optional[String] $hub_addr = undef,
+  Stdlib::Port $hub_port = 5646,
+  String $broker_addr = undef,
+  Stdlib::Port $broker_port = 5671,
+  String $sasl_mech = 'PLAIN',
+  String $sasl_username = 'katello_agent',
+  String $sasl_password = extlib::cache_data('foreman_cache_data', 'qpid_router_sasl_password', extlib::random_password(16)),
+) {
+  include foreman_proxy_content::dispatch_router
+
+  qpid::router::listener {'hub':
+    host        => $hub_addr,
+    port        => $hub_port,
+    role        => 'inter-router',
+    ssl_profile => 'server',
+  }
+
+  # Connect dispatch router to the local qpid
+  qpid::router::connector { 'broker':
+    host          => $broker_addr,
+    port          => $broker_port,
+    sasl_mech     => $sasl_mech,
+    sasl_username => $sasl_username,
+    sasl_password => $sasl_password,
+    ssl_profile   => 'client',
+    role          => 'route-container',
+    idle_timeout  => 0,
+  }
+
+  qpid::router::link_route { 'broker-pulp-route-out':
+    prefix     => 'pulp.',
+    direction  => 'out',
+    connection => 'broker',
+  }
+
+  qpid::router::link_route { 'broker-pulp-task-route-in':
+    prefix     => 'pulp.task',
+    direction  => 'in',
+    connection => 'broker',
+  }
+
+  qpid::router::link_route { 'broker-qmf-route-in':
+    prefix     => 'qmf.',
+    connection => 'broker',
+    direction  => 'in',
+  }
+
+  qpid::router::link_route { 'broker-qmf-route-out':
+    prefix     => 'qmf.',
+    connection => 'broker',
+    direction  => 'out',
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -180,7 +180,35 @@ class foreman_proxy_content (
 
   if $pulp_master or $pulp {
     if $qpid_router {
+      class { 'foreman_proxy_content::dispatch_router':
+        agent_addr    => $qpid_router_agent_addr,
+        agent_port    => $qpid_router_agent_port,
+        ssl_ciphers   => $qpid_router_ssl_ciphers,
+        ssl_protocols => $qpid_router_ssl_protocols,
+        logging_level => $qpid_router_logging_level,
+        logging       => $qpid_router_logging,
+        logging_path  => $qpid_router_logging_path,
+      }
       contain foreman_proxy_content::dispatch_router
+
+      if $pulp_master {
+        class { 'foreman_proxy_content::dispatch_router::hub':
+          hub_addr      => $qpid_router_hub_addr,
+          hub_port      => $qpid_router_hub_port,
+          broker_addr   => $qpid_router_broker_addr,
+          broker_port   => $qpid_router_broker_port,
+          sasl_mech     => $qpid_router_sasl_mech,
+          sasl_username => $qpid_router_sasl_username,
+          sasl_password => $qpid_router_sasl_password,
+        }
+        contain foreman_proxy_content::dispatch_router::hub
+      } else {
+        class { 'foreman_proxy_content::dispatch_router::connector':
+          host => $parent_fqdn,
+          port => $qpid_router_hub_port,
+        }
+        contain foreman_proxy_content::dispatch_router::connector
+      }
     }
 
     include certs::apache


### PR DESCRIPTION
This makes it clearer how it's used and allows standalone inclusion.