### PR TITLE
remove redundant ProxyPassReverse url

### DIFF
--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -51,7 +51,7 @@ class foreman_proxy_content::reverse_proxy (
       {
         'path'         => $path,
         'url'          => $url,
-        'reverse_urls' => [$path, $url],
+        'reverse_urls' => [$url],
         'params'       => $proxy_pass_params,
       }
     ],

--- a/spec/classes/foreman_proxy_content__reverse_proxy_spec.rb
+++ b/spec/classes/foreman_proxy_content__reverse_proxy_spec.rb
@@ -15,7 +15,7 @@ describe 'foreman_proxy_content::reverse_proxy' do
             .with_proxy_pass([{
               'path' => '/',
               'url' => "https://#{facts[:fqdn]}/",
-              'reverse_urls' => ['/', "https://#{facts[:fqdn]}/"],
+              'reverse_urls' => ["https://#{facts[:fqdn]}/"],
               'params' => {},
             }])
         end
@@ -32,7 +32,7 @@ describe 'foreman_proxy_content::reverse_proxy' do
             .with_proxy_pass([{
               'path' => '/',
               'url' => 'https://foreman.example.com/',
-              'reverse_urls' => ['/', 'https://foreman.example.com/'],
+              'reverse_urls' => ['https://foreman.example.com/'],
               'params' => {},
             }])
           is_expected.to contain_concat__fragment('katello-reverse-proxy-proxy')
@@ -55,7 +55,7 @@ describe 'foreman_proxy_content::reverse_proxy' do
               .with_proxy_pass([{
                 'path' => '/',
                 'url' => 'https://foreman.example.com/',
-                'reverse_urls' => ['/', 'https://foreman.example.com/'],
+                'reverse_urls' => ['https://foreman.example.com/'],
                 'params' => {'disablereuse' => 'on'},
               }])
             is_expected.to contain_concat__fragment('katello-reverse-proxy-proxy')


### PR DESCRIPTION
This PR is to remove the redundant 2nd ProxyPassReverse declaration discussed here: https://github.com/theforeman/puppet-foreman_proxy_content/pull/222#discussion_r354433015