### PR TITLE
Drop node_server_ca_cert parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -236,7 +236,6 @@ class foreman_proxy_content (
       puppet_wsgi_processes  => $pulp_puppet_wsgi_processes,
       num_workers            => $pulp_num_workers,
       repo_auth              => true,
-      node_server_ca_cert    => $certs::pulp_server_ca_cert,
       https_cert             => $certs::apache::apache_cert,
       https_key              => $certs::apache::apache_key,
       ssl_protocol           => $ssl_protocol,


### PR DESCRIPTION
233e31a9dea0053731ff64cb5ac6ddf92eef7172 stopped deploying pulp::child but didn't clean up the now unused parameter.