### PR TITLE
fixes #28655 - support fetching files via /pulp/isos with pulp3

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,8 @@
 #
 # $pulp_ca_cert::                       Absolute path to PEM encoded CA certificate file, used by Pulp to validate the identity of the broker using SSL.
 #
+# $proxy_pulp_isos_to_pulpcore::        Proxy /pulp/isos to pulpcore at /pulp/content
+#
 # $reverse_proxy::                      Add reverse proxy to the parent
 #
 # $reverse_proxy_port::                 Reverse proxy listening port
@@ -126,6 +128,7 @@ class foreman_proxy_content (
   Boolean $enable_ostree = $foreman_proxy_content::params::enable_ostree,
   Boolean $enable_yum = $foreman_proxy_content::params::enable_yum,
   Boolean $enable_file = $foreman_proxy_content::params::enable_file,
+  Boolean $proxy_pulp_isos_to_pulpcore = $foreman_proxy_content::params::proxy_pulp_isos_to_pulpcore,
   Boolean $enable_puppet = $foreman_proxy_content::params::enable_puppet,
   Boolean $enable_docker = $foreman_proxy_content::params::enable_docker,
   Boolean $enable_deb = $foreman_proxy_content::params::enable_deb,
@@ -247,7 +250,7 @@ class foreman_proxy_content (
     ~> class { 'pulp':
       enable_ostree          => $enable_ostree,
       enable_rpm             => $enable_yum,
-      enable_iso             => $enable_file,
+      enable_iso             => $enable_file and !$proxy_pulp_isos_to_pulpcore,
       enable_deb             => $enable_deb,
       enable_puppet          => $enable_puppet,
       enable_docker          => $enable_docker,
@@ -296,6 +299,12 @@ class foreman_proxy_content (
 
     foreman::config::apache::fragment { 'pulpcore':
       ssl_content => template('foreman_proxy_content/pulpcore-apache.conf.erb'),
+    }
+
+    if $proxy_pulp_isos_to_pulpcore {
+      foreman::config::apache::fragment { 'pulpcore-iso':
+        ssl_content => template('foreman_proxy_content/pulpcore-iso.conf.erb'),
+      }
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,52 +2,53 @@
 class foreman_proxy_content::params {
 
   # when not specified, we expect all in one installation
-  $parent_fqdn        = $facts['fqdn']
+  $parent_fqdn                 = $facts['fqdn']
 
-  $reverse_proxy      = false
-  $reverse_proxy_port = 8443
+  $reverse_proxy               = false
+  $reverse_proxy_port          = 8443
 
-  $ssl_protocol = undef
+  $ssl_protocol                = undef
 
-  $certs_tar = undef
-  $rhsm_hostname = undef
-  $rhsm_url = '/rhsm'
+  $certs_tar                   = undef
+  $rhsm_hostname               = undef
+  $rhsm_url                    = '/rhsm'
 
-  $puppet                    = true
+  $puppet                      = true
 
-  $pulp_admin_password       = extlib::cache_data('foreman_cache_data', 'pulp_node_admin_password', extlib::random_password(32))
-  $pulp_max_speed            = undef
-  $pulp_num_workers          = undef
-  $pulp_proxy_password       = undef
-  $pulp_proxy_port           = undef
-  $pulp_proxy_url            = undef
-  $pulp_proxy_username       = undef
-  $pulp_puppet_wsgi_processes = 1
-  $pulp_ca_cert              = undef
-  $pulp_worker_timeout       = 60
+  $pulp_admin_password         = extlib::cache_data('foreman_cache_data', 'pulp_node_admin_password', extlib::random_password(32))
+  $pulp_max_speed              = undef
+  $pulp_num_workers            = undef
+  $pulp_proxy_password         = undef
+  $pulp_proxy_port             = undef
+  $pulp_proxy_url              = undef
+  $pulp_proxy_username         = undef
+  $pulp_puppet_wsgi_processes  = 1
+  $pulp_ca_cert                = undef
+  $pulp_worker_timeout         = 60
 
-  $qpid_router               = true
-  $qpid_router_agent_addr    = undef
-  $qpid_router_agent_port    = 5647
-  $qpid_router_broker_addr   = 'localhost'
-  $qpid_router_broker_port   = 5671
-  $qpid_router_hub_addr      = undef
-  $qpid_router_hub_port      = 5646
-  $qpid_router_logging_level = 'info+'
-  $qpid_router_logging       = 'syslog'
-  $qpid_router_logging_path  = '/var/log/qdrouterd'
-  $qpid_router_ssl_ciphers   = undef
-  $qpid_router_ssl_protocols = undef
-  $qpid_router_sasl_mech   = 'PLAIN'
-  $qpid_router_sasl_username = 'katello_agent'
-  $qpid_router_sasl_password = extlib::cache_data('foreman_cache_data', 'qpid_router_sasl_password', extlib::random_password(16))
+  $qpid_router                 = true
+  $qpid_router_agent_addr      = undef
+  $qpid_router_agent_port      = 5647
+  $qpid_router_broker_addr     = 'localhost'
+  $qpid_router_broker_port     = 5671
+  $qpid_router_hub_addr        = undef
+  $qpid_router_hub_port        = 5646
+  $qpid_router_logging_level   = 'info+'
+  $qpid_router_logging         = 'syslog'
+  $qpid_router_logging_path    = '/var/log/qdrouterd'
+  $qpid_router_ssl_ciphers     = undef
+  $qpid_router_ssl_protocols   = undef
+  $qpid_router_sasl_mech       = 'PLAIN'
+  $qpid_router_sasl_username   = 'katello_agent'
+  $qpid_router_sasl_password   = extlib::cache_data('foreman_cache_data', 'qpid_router_sasl_password', extlib::random_password(16))
 
-  $enable_ostree             = false
-  $enable_yum                = true
-  $enable_file               = true
-  $enable_puppet             = true
-  $enable_docker             = true
-  $enable_deb                = true
+  $enable_ostree               = false
+  $enable_yum                  = true
+  $enable_file                 = true
+  $proxy_pulp_isos_to_pulpcore = true
+  $enable_puppet               = true
+  $enable_docker               = true
+  $enable_deb                  = true
 
-  $manage_broker             = true
+  $manage_broker               = true
 }

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -61,7 +61,8 @@ describe 'foreman_proxy_content' do
 
         it do
           is_expected.to contain_foreman__config__apache__fragment('pulpcore')
-		  .with_ssl_content(%r{ProxyPass /pulp/api/v3 http://127\.0\.0\.1:24817/pulp/api/v3})
+            .with_ssl_content(%r{ProxyPass /pulp/api/v3 http://127\.0\.0\.1:24817/pulp/api/v3})
+          is_expected.to contain_foreman__config__apache__fragment('pulpcore-iso')
         end
       end
 

--- a/templates/pulpcore-iso.conf.erb
+++ b/templates/pulpcore-iso.conf.erb
@@ -1,0 +1,2 @@
+ProxyPass /pulp/isos <%= scope['pulpcore::apache::content_url'] %>
+ProxyPassReverse /pulp/isos <%= scope['pulpcore::apache::content_url'] %>


### PR DESCRIPTION
This is a WIP. Currently it should disable isos for pulp2 when `$enable_pulpcore_file` but it does not yet add the vhost entry for proxying /pulp/isos to the pulpcore content app