### PR TITLE
Allow katello/certs 7.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,7 @@
     },
     {
       "name": "katello/certs",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
c55a889ad41a146965b5f37da8dee58d833d4c5e (https://github.com/theforeman/puppet-foreman_proxy_content/pull/232) added compatibility but missed the metadata.json fix.