### PR TITLE
Pass https_ca_cert to pulp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -273,6 +273,8 @@ class foreman_proxy_content (
       repo_auth              => true,
       https_cert             => $certs::apache::apache_cert,
       https_key              => $certs::apache::apache_key,
+      https_chain            => $certs::apache::apache_ca_cert,
+      https_ca_cert          => $certs::ca_cert,
       ssl_protocol           => $ssl_protocol,
       yum_max_speed          => $pulp_max_speed,
       proxy_port             => $pulp_proxy_port,


### PR DESCRIPTION
411e6adc6a20417c03e247713f000fd27d27996b stopped passing in `ca_cert`. When `https_ca_cert` is not passed in to pulp, it falls back to `ca_cert`. This now makes sure Apache serves the correct CA certificate matching the server certificate and the correct certificate for client cert authentication.

It also starts to pass `https_ca_chain`. This should make sure that the correct CA is presented when using custom certificates while still allowing CA authentication using the default CA.