### PR TITLE
Fixes #28983 - Allow integers for $proxy_pass_params

### DIFF
--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -21,7 +21,7 @@ class foreman_proxy_content::reverse_proxy (
   Stdlib::Port $port = $foreman_proxy_content::reverse_proxy_port,
   Variant[Array[String], String, Undef] $ssl_protocol = undef,
   Hash[String, Any] $vhost_params = {},
-  Hash[String, String] $proxy_pass_params = {},
+  Hash[String, Variant[String, Integer]] $proxy_pass_params = {},
 ) {
   include apache
   include certs::apache


### PR DESCRIPTION
f95a6eef1d510e65e2499367d738935b151cd05c added a parameter to allow setting parameters to proxy_pass but only accepted strings. When setting this via hiera, values like TTL will usually end up as integers and are valid. This can be worked around by quoting them in hiera, but it's a bad user experience.