### PR TITLE
Use loose coupling to Foreman's Apache config

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -338,16 +338,13 @@ class foreman_proxy_content (
     include pulpcore::plugin::container
     include pulpcore::plugin::file
 
-    foreman::config::apache::fragment { 'pulpcore-https':
+    foreman::config::apache::fragment { 'pulpcore':
+      content     => template('foreman_proxy_content/pulpcore-content-apache.conf.erb'),
       ssl_content => template(
         'foreman_proxy_content/pulpcore-api-apache.conf.erb',
         'foreman_proxy_content/pulpcore-content-apache.conf.erb',
         'foreman_proxy_content/pulpcore-docker-apache.conf.erb'
       ),
-    }
-
-    foreman::config::apache::fragment { 'pulpcore-http':
-      content => template('foreman_proxy_content/pulpcore-content-apache.conf.erb'),
     }
 
     if $proxy_pulp_isos_to_pulpcore {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -306,12 +306,12 @@ class foreman_proxy_content (
   }
 
   if $pulpcore and !$pulpcore_mirror {
-    include foreman
+    include foreman::config::apache
 
     class { 'pulpcore':
       remote_user_environ_name => 'HTTP_REMOTE_USER',
       manage_apache            => false,
-      servername               => $foreman::servername,
+      servername               => $foreman::config::apache::servername,
       postgresql_manage_db     => $pulpcore_manage_postgresql,
       postgresql_db_host       => $pulpcore_postgresql_host,
       postgresql_db_port       => $pulpcore_postgresql_port,

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -60,11 +60,10 @@ describe 'foreman_proxy_content' do
         it { is_expected.to contain_class('pulpcore').with(manage_apache: false) }
 
         it do
-          is_expected.to contain_foreman__config__apache__fragment('pulpcore-https')
+          is_expected.to contain_foreman__config__apache__fragment('pulpcore')
             .with_ssl_content(%r{ProxyPass /pulp/api/v3 http://127\.0\.0\.1:24817/pulp/api/v3})
             .with_ssl_content(%r{ProxyPass /pulp/content http://127\.0\.0\.1:24816/pulp/content})
             .with_ssl_content(%r{ProxyPass /pulpcore_registry/v2/ http://127\.0\.0\.1:24816/v2/})
-          is_expected.to contain_foreman__config__apache__fragment('pulpcore-http')
             .with_content(%r{ProxyPass /pulp/content http://127\.0\.0\.1:24816/pulp/content})
           is_expected.to contain_foreman__config__apache__fragment('pulpcore-isos')
             .with_content(%r{ProxyPass /pulp/isos http://127\.0\.0\.1:24816/pulp/content})


### PR DESCRIPTION
By only including the Apache config, we get only what we really need. This depends on https://github.com/theforeman/puppet-foreman/pull/800

Also uses a single Apache fragment for both HTTP and HTTPS.