### PR TITLE
Fixes #29589 - Ensure pulpcore before proxy

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -338,6 +338,7 @@ class foreman_proxy_content (
       postgresql_db_ssl_cert    => $pulpcore_postgresql_ssl_cert,
       postgresql_db_ssl_key     => $pulpcore_postgresql_ssl_key,
       postgresql_db_ssl_root_ca => $pulpcore_postgresql_ssl_root_ca,
+      before                    => Class['foreman_proxy::plugin::pulp'],
     }
 
     if $pulp_master {

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -57,7 +57,7 @@ describe 'foreman_proxy_content' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_class('pulpcore').with(manage_apache: false) }
+        it { is_expected.to contain_class('pulpcore').with(manage_apache: false).that_comes_before('Class[foreman_proxy::plugin::pulp]') }
 
         it do
           is_expected.to contain_foreman__config__apache__fragment('pulpcore')


### PR DESCRIPTION
When the Foreman Proxy registration happens, Pulp's features are queried and presented as capabilities. If the service is down, Katello can't detect the right content types.