### PR TITLE
Fixes #29660 - Serve Pulpcore ISO via HTTPS

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -375,7 +375,8 @@ class foreman_proxy_content (
 
     if $proxy_pulp_isos_to_pulpcore {
       foreman::config::apache::fragment { 'pulpcore-isos':
-        content => template('foreman_proxy_content/pulpcore-isos-apache.conf.erb'),
+        content     => template('foreman_proxy_content/pulpcore-isos-apache.conf.erb'),
+        ssl_content => template('foreman_proxy_content/pulpcore-isos-apache.conf.erb'),
       }
     }
   }


### PR DESCRIPTION
132d38fe89b614d191aeef58f30c794ec0366f88 added code to serve /pulp/iso over HTTP but this also needs to be served over HTTPS.

@jlsherrill can you confirm this fixes it?