### PR TITLE
Fixes #30716: Ensure /pub on foreman proxy can be browsed by default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -329,6 +329,8 @@ class foreman_proxy_content (
       worker_timeout         => $pulp_worker_timeout,
     }
 
+    $pub_dir_options = '+FollowSymLinks +Indexes'
+
     pulp::apache::fragment{'gpg_key_proxy':
       ssl_content => template('foreman_proxy_content/_pulp_gpg_proxy.erb', 'foreman_proxy_content/httpd_pub.erb'),
     }


### PR DESCRIPTION
Fixes regression introduced by f6790c4

(cherry picked from commit 8cfa178046a4dcd80f9e21c2f517f2cc75f67bcf)