### PR TITLE
Set up a pub_dir vhost on non-Pulp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -267,6 +267,8 @@ class foreman_proxy_content (
       require      => Class['certs::apache'],
     }
 
+    ensure_packages('katello-client-bootstrap')
+  } else {
     include foreman_proxy_content::pub_dir
   }
 

--- a/manifests/pub_dir.pp
+++ b/manifests/pub_dir.pp
@@ -17,12 +17,11 @@ class foreman_proxy_content::pub_dir (
   ensure_packages('katello-client-bootstrap')
 
   apache::vhost { 'foreman_proxy_content':
-    servername          => $servername,
-    port                => 80,
-    priority            => '05',
-    docroot             => '/var/www/html',
-    options             => ['SymLinksIfOwnerMatch'],
-    additional_includes => ["${apache::confd_dir}/pulp-vhosts80/*.conf"],
-    custom_fragment     => template('foreman_proxy_content/httpd_pub.erb'),
+    servername      => $servername,
+    port            => 80,
+    priority        => '05',
+    docroot         => '/var/www/html',
+    options         => ['SymLinksIfOwnerMatch'],
+    custom_fragment => template('foreman_proxy_content/httpd_pub.erb'),
   }
 }


### PR DESCRIPTION
In puppet-katello the /pub alias is set up as part of the foreman vhost on port 80 via katello::pulp. If Pulp 2 is managed by this module, the /pub alias is set up as part of the Pulp 2 HTTP vhost. That means it's only needed if Pulp 2 is not present at all, the foreman_proxy_content vhost is needed. It does mean that katello-client-bootstrap needs to be ensured in the case where Pulp 2 is present.

This also means the additional pulp-vhost80 includes are not needed.

I haven't verified this yet, but it's based on https://github.com/theforeman/puppet-foreman_proxy_content/pull/282/files#r486961343.