### PR TITLE
Set reverse proxy servername via certs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -219,7 +219,6 @@ class foreman_proxy_content (
     ~> class { 'foreman_proxy_content::reverse_proxy':
       path         => '/',
       url          => "${foreman_url}/",
-      servername   => $foreman_proxy_fqdn,
       port         => $reverse_proxy_port,
       subscribe    => Class['certs::foreman_proxy'],
       ssl_protocol => $ssl_protocol,

--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -4,8 +4,6 @@
 #   The path where to mount the reverse proxy
 # @param url
 #   The URL to forward to
-# @param servername
-#   The Apache vhost server name to listen on
 # @param port
 #   The port to listen on
 # @param ssl_protocol
@@ -17,7 +15,6 @@
 class foreman_proxy_content::reverse_proxy (
   Stdlib::Unixpath $path = '/',
   Stdlib::Httpurl $url = "${foreman_proxy_content::foreman_url}/",
-  Stdlib::Fqdn $servername = $foreman_proxy_content::foreman_proxy_fqdn,
   Stdlib::Port $port = $foreman_proxy_content::reverse_proxy_port,
   Variant[Array[String], String, Undef] $ssl_protocol = undef,
   Hash[String, Any] $vhost_params = {},
@@ -30,7 +27,8 @@ class foreman_proxy_content::reverse_proxy (
   Class['certs', 'certs::ca', 'certs::apache', 'certs::foreman_proxy'] ~> Class['apache::service']
 
   apache::vhost { 'katello-reverse-proxy':
-    servername             => $servername,
+    servername             => $certs::apache::hostname,
+    aliases                => $certs::apache::cname,
     port                   => $port,
     docroot                => '/var/www/',
     priority               => '28',

--- a/spec/classes/foreman_proxy_content__reverse_proxy_spec.rb
+++ b/spec/classes/foreman_proxy_content__reverse_proxy_spec.rb
@@ -22,6 +22,7 @@ describe 'foreman_proxy_content::reverse_proxy' do
         it do
           is_expected.to contain_apache__vhost('katello-reverse-proxy')
             .with_servername(facts[:fqdn])
+            .with_aliases([])
             .with_port(8443)
             .with_proxy_pass([{
               'path' => '/',
@@ -33,22 +34,13 @@ describe 'foreman_proxy_content::reverse_proxy' do
       end
 
       describe 'with explicit parameters' do
-        let(:params) { { url: 'https://foreman.example.com/', servername: 'proxy.example.com', port: 443 } }
-
-        let(:pre_condition) do
-          <<-PUPPET
-          include foreman_proxy
-          class { 'foreman_proxy::plugin::pulp':
-            enabled          => false,
-            pulpnode_enabled => false,
-          }
-          PUPPET
-        end
+        let(:params) { { url: 'https://foreman.example.com/', port: 443 } }
 
         it { is_expected.to compile.with_all_deps }
         it do
           is_expected.to contain_apache__vhost('katello-reverse-proxy')
-            .with_servername('proxy.example.com')
+            .with_servername('foo.example.com')
+            .with_aliases([])
             .with_port(443)
             .without_keepalive # Not part of the vhost but used in the vhost_params
             .with_proxy_pass([{
@@ -59,6 +51,24 @@ describe 'foreman_proxy_content::reverse_proxy' do
             }])
           is_expected.to contain_concat__fragment('katello-reverse-proxy-proxy')
             .with_content(%r{^\s+ProxyPass / https://foreman\.example\.com/$})
+        end
+
+        describe 'with custom servername and cnames' do
+          let(:pre_condition) do
+            <<-PUPPET
+            class { 'certs::apache':
+              hostname => 'proxy.example.com',
+              cname    => ['proxy-01.example.com'],
+            }
+            PUPPET
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it do
+            is_expected.to contain_apache__vhost('katello-reverse-proxy')
+              .with_servername('proxy.example.com')
+              .with_aliases(['proxy-01.example.com'])
+          end
         end
 
         describe 'with vhost_params' do


### PR DESCRIPTION
The certs class already has the correct servername (set via init.pp) so this avoids a mismatch. It also adds aliases via the CNAME, which is new functionality.