### PR TITLE
Generate beaker setfiles on the fly

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -2,9 +2,19 @@ name: Acceptance tests
 
 on: pull_request
 
+env:
+  BUNDLE_PATH: vendor/bundle
+  BUNDLE_WITHOUT: development:test
+  BUNDLE_JOBS: 4
+  BUNDLE_RETRY: 3
+
 jobs:
-  build_cache:
+  setup_matrix:
+    name: 'Setup Test Matrix'
     runs-on: ubuntu-latest
+    outputs:
+      setfiles: ${{ steps.get-setfiles.outputs.setfiles }}
+      puppet_major_versions: ${{ steps.get-setfiles.outputs.puppet_major_versions }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
@@ -20,23 +30,21 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler
-          bundle config path vendor/bundle
-          bundle config without 'development test'
-          bundle install --jobs 4 --retry 3
+          bundle install
+          bundle clean
+      - name: Setup Acceptance Test Matrix
+        id: get-setfiles
+        run: bundle exec metadata2gha-beaker --use-fqdn --pidfile-workaround false
 
   acceptance:
-    needs: build_cache
+    needs: setup_matrix
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        setfile:
-          - centos7-64{hostname=centos7-64.example.com}
-          - centos8-64{hostname=centos8-64.example.com}
-        puppet:
-          - "6"
-          - "5"
-    name: Puppet ${{ matrix.puppet }} - ${{ matrix.setfile }}
+        setfile: ${{fromJson(needs.setup_matrix.outputs.setfiles)}}
+        puppet: ${{fromJson(needs.setup_matrix.outputs.puppet_major_versions)}}
+    name: Puppet ${{ matrix.puppet }} - ${{ matrix.setfile.name }}
     steps:
       - name: Enable IPv6 on docker
         run: |
@@ -56,11 +64,9 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler
-          bundle config path vendor/bundle
-          bundle config without 'development test'
-          bundle install --jobs 4 --retry 3
+          bundle install
       - name: Run tests
         run: bundle exec rake beaker
         env:
           BEAKER_PUPPET_COLLECTION: puppet${{ matrix.puppet }}
-          BEAKER_setfile: ${{ matrix.setfile }}
+          BEAKER_setfile: ${{ matrix.setfile.value }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '4 4 * * *'
 
+env:
+  BUNDLE_PATH: vendor/bundle
+  BUNDLE_JOBS: 4
+  BUNDLE_RETRY: 3
+
 jobs:
   unit:
     if: github.repository == 'theforeman/puppet-foreman_proxy_content'
@@ -23,6 +28,7 @@ jobs:
           - ruby: "2.4"
             puppet: "6"
     env:
+      BUNDLE_WITHOUT: development:system_tests
       PUPPET_VERSION: "${{ matrix.puppet }}.0"
     name: Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
@@ -40,15 +46,20 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler
-          bundle config path vendor/bundle
-          bundle config without 'development system_tests'
-          bundle install --jobs 4 --retry 3
+          bundle install
+          bundle clean
       - name: Run tests
         run: bundle exec rake
 
-  build_cache:
+  setup_matrix:
+    name: 'Setup Test Matrix'
     if: github.repository == 'theforeman/puppet-foreman_proxy_content'
     runs-on: ubuntu-latest
+    outputs:
+      setfiles: ${{ steps.get-setfiles.outputs.setfiles }}
+      puppet_major_versions: ${{ steps.get-setfiles.outputs.puppet_major_versions }}
+    env:
+      BUNDLE_WITHOUT: development:test
     steps:
       - name: Enable IPv6 on docker
         run: |
@@ -68,24 +79,27 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler
-          bundle config path vendor/bundle
-          bundle config without 'development test'
-          bundle install --jobs 4 --retry 3
+          bundle install
+          bundle clean
+      - name: Setup Acceptance Test Matrix
+        id: get-setfiles
+        run: bundle exec metadata2gha-beaker --use-fqdn --pidfile-workaround false
 
   acceptance:
     if: github.repository == 'theforeman/puppet-foreman_proxy_content'
     needs: build_cache
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_WITHOUT: development:test
     strategy:
       fail-fast: false
       matrix:
-        setfile:
-          - centos7-64{hostname=centos7-64.example.com}
-          - centos8-64{hostname=centos8-64.example.com}
+        setfile: ${{fromJson(needs.setup_matrix.outputs.setfiles)}}
+        puppet: ${{fromJson(needs.setup_matrix.outputs.puppet_major_versions)}}
         puppet:
           - "6"
           - "5"
-    name: Puppet ${{ matrix.puppet }} - ${{ matrix.setfile }}
+    name: Puppet ${{ matrix.puppet }} - ${{ matrix.setfile.name }}
     steps:
       - name: Enable IPv6 on docker
         run: |
@@ -105,11 +119,9 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler
-          bundle config path vendor/bundle
-          bundle config without 'development test'
-          bundle install --jobs 4 --retry 3
+          bundle install
       - name: Run tests
         run: bundle exec rake beaker
         env:
           BEAKER_PUPPET_COLLECTION: puppet${{ matrix.puppet }}
-          BEAKER_setfile: ${{ matrix.setfile }}
+          BEAKER_setfile: ${{ matrix.setfile.value }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -2,6 +2,12 @@ name: Unit tests
 
 on: pull_request
 
+env:
+  BUNDLE_PATH: vendor/bundle
+  BUNDLE_WITHOUT: development:system_tests
+  BUNDLE_JOBS: 4
+  BUNDLE_RETRY: 3
+
 jobs:
   unit:
     runs-on: ubuntu-latest
@@ -37,8 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler
-          bundle config path vendor/bundle
-          bundle config without 'development system_tests'
-          bundle install --jobs 4 --retry 3
+          bundle install
+          bundle clean
       - name: Run tests
         run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'puppet-lint-undef_in_function-check', {"groups"=>["test"]}
 gem 'voxpupuli-test', '~> 1.4'
 gem 'github_changelog_generator', '>= 1.15.0', {"groups"=>["development"]}
 gem 'puppet-blacksmith', '>= 6.0.0', {"groups"=>["development"]}
-gem 'voxpupuli-acceptance', '~> 0.2', {"groups"=>["system_tests"]}
+gem 'voxpupuli-acceptance', '~> 0.3', {"groups"=>["system_tests"]}
+gem 'puppet_metadata', {"git"=>"https://github.com/ekohl/puppet_metadata", "branch"=>"metadata2gha-beaker", "groups"=>["system_tests"]}
 
 # vim:ft=ruby

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Puppet Forge](https://img.shields.io/puppetforge/v/katello/foreman_proxy_content.svg)](https://forge.puppetlabs.com/katello/foreman_proxy_content)
-[![Build Status](https://travis.ci.org/theforeman/puppet-foreman_proxy_content.svg?branch=master)](https://travis-ci.org/Katello/puppet-foreman_proxy_content)
+![Nightly tests](https://github.com/theforeman/puppet-foreman_proxy_content/workflows/Nightly%20tests/badge.svg)
 
 #### Table of Contents
 
@@ -19,6 +19,7 @@ This module is designed to configure a Foreman proxy server for Katello content 
 ## Limitations
 
 * EL7 (RHEL7 / CentOS 7)
+* EL8 (RHEL8 / CentOS 8)
 
 ## Development
 


### PR DESCRIPTION
Draft PR to test out https://github.com/voxpupuli/puppet_metadata/pull/11. The goal is to avoid the duplication of setfiles. It modifies the cache building into a matrix generation step.