### PR TITLE
Add proxy_pulp_deb_to_pulpcore parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,8 @@
 #
 # $pulp_ca_cert::                       Absolute path to PEM encoded CA certificate file, used by Pulp to validate the identity of the broker using SSL.
 #
+# $proxy_pulp_deb_to_pulpcore::         Proxy /pulp/deb to Pulpcore at /pulp/content
+#
 # $proxy_pulp_isos_to_pulpcore::        Proxy /pulp/isos to Pulpcore at /pulp/content
 #
 # $proxy_pulp_yum_to_pulpcore::         Proxy /pulp/yum to Pulpcore at /pulp/content
@@ -150,6 +152,7 @@ class foreman_proxy_content (
   Boolean $enable_ostree = $foreman_proxy_content::params::enable_ostree,
   Boolean $enable_yum = $foreman_proxy_content::params::enable_yum,
   Boolean $enable_file = $foreman_proxy_content::params::enable_file,
+  Boolean $proxy_pulp_deb_to_pulpcore = $foreman_proxy_content::params::proxy_pulp_deb_to_pulpcore,
   Boolean $proxy_pulp_isos_to_pulpcore = $foreman_proxy_content::params::proxy_pulp_isos_to_pulpcore,
   Boolean $proxy_pulp_yum_to_pulpcore = $foreman_proxy_content::params::proxy_pulp_yum_to_pulpcore,
   Boolean $enable_puppet = $foreman_proxy_content::params::enable_puppet,
@@ -180,6 +183,7 @@ class foreman_proxy_content (
   $pulpcore_mirror = $foreman_proxy::plugin::pulp::pulpcore_mirror
   $pulpcore = $foreman_proxy::plugin::pulp::pulpcore_enabled
 
+  $enable_pulp2_deb = $enable_deb and !($pulpcore and $proxy_pulp_deb_to_pulpcore)
   $enable_pulp2_rpm = $enable_yum and !($pulpcore and $proxy_pulp_yum_to_pulpcore)
   $enable_pulp2_iso = $enable_file and !($pulpcore and $proxy_pulp_isos_to_pulpcore)
 
@@ -410,6 +414,9 @@ class foreman_proxy_content (
     }
 
     include pulpcore::plugin::container
+    class { 'pulpcore::plugin::deb':
+      use_pulp2_content_route => $proxy_pulp_deb_to_pulpcore,
+    }
     class { 'pulpcore::plugin::file':
       use_pulp2_content_route => $proxy_pulp_isos_to_pulpcore,
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,6 +45,7 @@ class foreman_proxy_content::params {
   $enable_ostree                = false
   $enable_yum                   = true
   $enable_file                  = true
+  $proxy_pulp_deb_to_pulpcore   = true
   $proxy_pulp_isos_to_pulpcore  = true
   $proxy_pulp_yum_to_pulpcore   = true
   $enable_puppet                = true


### PR DESCRIPTION
Enable proxying of pulp_deb for pulpcore.
Dependent code in theforeman/puppet-pulpcore was implemented by @jlsherrill and already merged in https://github.com/theforeman/puppet-pulpcore/pull/145