### PR TITLE
Don't enable Pulp2 Deb with Pulpcore

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -301,7 +301,7 @@ class foreman_proxy_content (
       enable_ostree          => $enable_ostree,
       enable_rpm             => $enable_pulp2_rpm,
       enable_iso             => $enable_pulp2_iso,
-      enable_deb             => $enable_deb,
+      enable_deb             => $enable_pulp2_deb,
       enable_puppet          => $enable_puppet,
       enable_docker          => $enable_docker,
       default_password       => $pulp_admin_password,


### PR DESCRIPTION
This fixes an issue in https://github.com/theforeman/puppet-foreman_proxy_content/commit/1d2eef1b71a5c1c5904f9447c05f7a3902cf5c1c

CC: @jlsherrill , we missed this one