### PR TITLE
Fixes #31385 - Default to strict qpid-router ciphers

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,7 +144,7 @@ class foreman_proxy_content (
   String $qpid_router_logging_level = 'info+',
   Enum['file', 'syslog'] $qpid_router_logging = 'syslog',
   Stdlib::Absolutepath $qpid_router_logging_path = '/var/log/qdrouterd',
-  Optional[String] $qpid_router_ssl_ciphers = undef,
+  String $qpid_router_ssl_ciphers = 'ALL:!aNULL:+HIGH:-SSLv3:!IDEA-CBC-SHA',
   Optional[Array[String]] $qpid_router_ssl_protocols = undef,
   Optional[String] $qpid_router_sasl_mech = 'PLAIN',
   Optional[String] $qpid_router_sasl_username = 'katello_agent',


### PR DESCRIPTION
Prior to this weak and insecure ciphers were used. While this change only mentions ciphers, in practice it looked like it also disabled TLS 1.0 and 1.1

Before:

    $ nmap --script +ssl-enum-ciphers -p 5646,5647 centos7.wisse.example.com
    Starting Nmap 7.80 ( https://nmap.org ) at 2020-11-24 17:44 CET
    Nmap scan report for centos7.wisse.example.com (192.168.122.167)
    Host is up (0.00018s latency).

    PORT     STATE SERVICE
    5646/tcp open  vfmobile
    | ssl-enum-ciphers:
    |   TLSv1.0:
    |     ciphers:
    |       TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA (dh 2048) - C
    |       TLS_DHE_RSA_WITH_AES_128_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_256_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_SEED_CBC_SHA (dh 2048) - A
    |       TLS_RSA_WITH_3DES_EDE_CBC_SHA (rsa 4096) - C
    |       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_CAMELLIA_128_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_CAMELLIA_256_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_IDEA_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_RC4_128_MD5 (rsa 4096) - C
    |       TLS_RSA_WITH_RC4_128_SHA (rsa 4096) - C
    |       TLS_RSA_WITH_SEED_CBC_SHA (rsa 4096) - A
    |     compressors:
    |       NULL
    |     cipher preference: client
    |     warnings:
    |       64-bit block cipher 3DES vulnerable to SWEET32 attack
    |       64-bit block cipher IDEA vulnerable to SWEET32 attack
    |       Broken cipher RC4 is deprecated by RFC 7465
    |       Ciphersuite uses MD5 for message integrity
    |       Key exchange (dh 2048) of lower strength than certificate key
    |   TLSv1.1:
    |     ciphers:
    |       TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA (dh 2048) - C
    |       TLS_DHE_RSA_WITH_AES_128_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_256_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_SEED_CBC_SHA (dh 2048) - A
    |       TLS_RSA_WITH_3DES_EDE_CBC_SHA (rsa 4096) - C
    |       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_CAMELLIA_128_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_CAMELLIA_256_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_IDEA_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_RC4_128_MD5 (rsa 4096) - C
    |       TLS_RSA_WITH_RC4_128_SHA (rsa 4096) - C
    |       TLS_RSA_WITH_SEED_CBC_SHA (rsa 4096) - A
    |     compressors:
    |       NULL
    |     cipher preference: client
    |     warnings:
    |       64-bit block cipher 3DES vulnerable to SWEET32 attack
    |       64-bit block cipher IDEA vulnerable to SWEET32 attack
    |       Broken cipher RC4 is deprecated by RFC 7465
    |       Ciphersuite uses MD5 for message integrity
    |       Key exchange (dh 2048) of lower strength than certificate key
    |   TLSv1.2:
    |     ciphers:
    |       TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA (dh 2048) - C
    |       TLS_DHE_RSA_WITH_AES_128_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_128_CBC_SHA256 (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_256_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_256_CBC_SHA256 (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 (dh 2048) - A
    |       TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_SEED_CBC_SHA (dh 2048) - A
    |       TLS_RSA_WITH_3DES_EDE_CBC_SHA (rsa 4096) - C
    |       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_AES_128_CBC_SHA256 (rsa 4096) - A
    |       TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 4096) - A
    |       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_AES_256_CBC_SHA256 (rsa 4096) - A
    |       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 4096) - A
    |       TLS_RSA_WITH_CAMELLIA_128_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_CAMELLIA_256_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_IDEA_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_RC4_128_MD5 (rsa 4096) - C
    |       TLS_RSA_WITH_RC4_128_SHA (rsa 4096) - C
    |       TLS_RSA_WITH_SEED_CBC_SHA (rsa 4096) - A
    |     compressors:
    |       NULL
    |     cipher preference: client
    |     warnings:
    |       64-bit block cipher 3DES vulnerable to SWEET32 attack
    |       64-bit block cipher IDEA vulnerable to SWEET32 attack
    |       Broken cipher RC4 is deprecated by RFC 7465
    |       Ciphersuite uses MD5 for message integrity
    |       Key exchange (dh 2048) of lower strength than certificate key
    |_  least strength: C
    5647/tcp open  unknown
    | ssl-enum-ciphers:
    |   TLSv1.0:
    |     ciphers:
    |       TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA (dh 2048) - C
    |       TLS_DHE_RSA_WITH_AES_128_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_256_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_SEED_CBC_SHA (dh 2048) - A
    |       TLS_RSA_WITH_3DES_EDE_CBC_SHA (rsa 4096) - C
    |       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_CAMELLIA_128_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_CAMELLIA_256_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_IDEA_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_RC4_128_MD5 (rsa 4096) - C
    |       TLS_RSA_WITH_RC4_128_SHA (rsa 4096) - C
    |       TLS_RSA_WITH_SEED_CBC_SHA (rsa 4096) - A
    |     compressors:
    |       NULL
    |     cipher preference: client
    |     warnings:
    |       64-bit block cipher 3DES vulnerable to SWEET32 attack
    |       64-bit block cipher IDEA vulnerable to SWEET32 attack
    |       Broken cipher RC4 is deprecated by RFC 7465
    |       Ciphersuite uses MD5 for message integrity
    |       Key exchange (dh 2048) of lower strength than certificate key
    |   TLSv1.1:
    |     ciphers:
    |       TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA (dh 2048) - C
    |       TLS_DHE_RSA_WITH_AES_128_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_256_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_SEED_CBC_SHA (dh 2048) - A
    |       TLS_RSA_WITH_3DES_EDE_CBC_SHA (rsa 4096) - C
    |       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_CAMELLIA_128_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_CAMELLIA_256_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_IDEA_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_RC4_128_MD5 (rsa 4096) - C
    |       TLS_RSA_WITH_RC4_128_SHA (rsa 4096) - C
    |       TLS_RSA_WITH_SEED_CBC_SHA (rsa 4096) - A
    |     compressors:
    |       NULL
    |     cipher preference: client
    |     warnings:
    |       64-bit block cipher 3DES vulnerable to SWEET32 attack
    |       64-bit block cipher IDEA vulnerable to SWEET32 attack
    |       Broken cipher RC4 is deprecated by RFC 7465
    |       Ciphersuite uses MD5 for message integrity
    |       Key exchange (dh 2048) of lower strength than certificate key
    |   TLSv1.2:
    |     ciphers:
    |       TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA (dh 2048) - C
    |       TLS_DHE_RSA_WITH_AES_128_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_128_CBC_SHA256 (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_256_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_256_CBC_SHA256 (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 (dh 2048) - A
    |       TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA (dh 2048) - A
    |       TLS_DHE_RSA_WITH_SEED_CBC_SHA (dh 2048) - A
    |       TLS_RSA_WITH_3DES_EDE_CBC_SHA (rsa 4096) - C
    |       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_AES_128_CBC_SHA256 (rsa 4096) - A
    |       TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 4096) - A
    |       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_AES_256_CBC_SHA256 (rsa 4096) - A
    |       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 4096) - A
    |       TLS_RSA_WITH_CAMELLIA_128_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_CAMELLIA_256_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_IDEA_CBC_SHA (rsa 4096) - A
    |       TLS_RSA_WITH_RC4_128_MD5 (rsa 4096) - C
    |       TLS_RSA_WITH_RC4_128_SHA (rsa 4096) - C
    |       TLS_RSA_WITH_SEED_CBC_SHA (rsa 4096) - A
    |     compressors:
    |       NULL
    |     cipher preference: client
    |     warnings:
    |       64-bit block cipher 3DES vulnerable to SWEET32 attack
    |       64-bit block cipher IDEA vulnerable to SWEET32 attack
    |       Broken cipher RC4 is deprecated by RFC 7465
    |       Ciphersuite uses MD5 for message integrity
    |       Key exchange (dh 2048) of lower strength than certificate key
    |_  least strength: C

    Nmap done: 1 IP address (1 host up) scanned in 1.22 seconds

After:

    $ nmap --script +ssl-enum-ciphers -p 5646,5647 centos7.wisse.example.com
    Starting Nmap 7.80 ( https://nmap.org ) at 2020-11-24 17:45 CET
    Nmap scan report for centos7.wisse.example.com (192.168.122.167)
    Host is up (0.00022s latency).

    PORT     STATE SERVICE
    5646/tcp open  vfmobile
    | ssl-enum-ciphers:
    |   TLSv1.2:
    |     ciphers:
    |       TLS_DHE_RSA_WITH_AES_128_CBC_SHA256 (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_256_CBC_SHA256 (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 (dh 2048) - A
    |       TLS_RSA_WITH_AES_128_CBC_SHA256 (rsa 4096) - A
    |       TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 4096) - A
    |       TLS_RSA_WITH_AES_256_CBC_SHA256 (rsa 4096) - A
    |       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 4096) - A
    |     compressors:
    |       NULL
    |     cipher preference: client
    |     warnings:
    |       Key exchange (dh 2048) of lower strength than certificate key
    |_  least strength: A
    5647/tcp open  unknown
    | ssl-enum-ciphers:
    |   TLSv1.2:
    |     ciphers:
    |       TLS_DHE_RSA_WITH_AES_128_CBC_SHA256 (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_256_CBC_SHA256 (dh 2048) - A
    |       TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 (dh 2048) - A
    |       TLS_RSA_WITH_AES_128_CBC_SHA256 (rsa 4096) - A
    |       TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 4096) - A
    |       TLS_RSA_WITH_AES_256_CBC_SHA256 (rsa 4096) - A
    |       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 4096) - A
    |     compressors:
    |       NULL
    |     cipher preference: client
    |     warnings:
    |       Key exchange (dh 2048) of lower strength than certificate key
    |_  least strength: A

    Nmap done: 1 IP address (1 host up) scanned in 0.57 seconds