### PR TITLE
Simplify reverse proxy definition

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -209,12 +209,10 @@ class foreman_proxy_content (
     rhsm_port => $rhsm_port,
   }
 
-  if $pulp or $reverse_proxy_real {
+  if $reverse_proxy_real {
     class { 'foreman_proxy_content::reverse_proxy':
-      path      => '/',
-      url       => "${foreman_url}/",
-      port      => $reverse_proxy_port,
-      subscribe => Class['certs::foreman_proxy'],
+      url  => "${foreman_url}/",
+      port => $reverse_proxy_port,
     }
   }
 


### PR DESCRIPTION
$reverse_proxy_real is by definition already true if $pulp is true, so the or clause is redundant.

It already internally handles the subscribe on certs::foreman_proxy so that's also redundant.

Lastly, we can rely on the default value `/` of the path.