### PR TITLE
Drop parent_fqdn in favor of deriving from foreman_url

### DIFF
--- a/lib/puppet/functions/foreman_proxy_content/host_from_url.rb
+++ b/lib/puppet/functions/foreman_proxy_content/host_from_url.rb
@@ -1,0 +1,19 @@
+require 'uri'
+
+# @summary Parses a URL and returns the host
+#
+# @example Calling the function
+#   $host = foreman_proxy_content::host_from_url('https://test.example.com')
+Puppet::Functions.create_function(:'foreman_proxy_content::host_from_url') do
+  # @param url URL to parse
+  # @return The host found within the URL
+  dispatch :host do
+    param 'Stdlib::HTTPUrl', :url
+    return_type 'Stdlib::Host'
+  end
+
+  def host(url)
+    uri = URI(url)
+    uri.host
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,8 +4,6 @@
 #
 # === Parameters:
 #
-# $parent_fqdn::                        FQDN of the parent node.
-#
 # $enable_ostree::                      Enable ostree content plugin, this requires an ostree install
 #
 # $enable_yum::                         Enable rpm content plugin, including syncing of yum content
@@ -114,7 +112,6 @@
 #                                       incrementally with benchmarking at each step to determine an optimal value for your deployment.
 #
 class foreman_proxy_content (
-  String[1] $parent_fqdn = $foreman_proxy_content::params::parent_fqdn,
   String $pulp_admin_password = $foreman_proxy_content::params::pulp_admin_password,
   Optional[String] $pulp_max_speed = undef,
   Optional[Integer[1]] $pulp_num_workers = undef,
@@ -185,6 +182,7 @@ class foreman_proxy_content (
   $enable_pulp2_deb = $enable_deb and !($pulpcore and $proxy_pulp_deb_to_pulpcore)
 
   $foreman_url = $foreman_proxy::foreman_base_url
+  $foreman_host = foreman_proxy_content::host_from_url($foreman_url)
   $reverse_proxy_real = ($pulp or $pulpcore_mirror) or $reverse_proxy
 
   # TODO: doesn't allow deploying a Pulp non-mirror without Foreman
@@ -242,7 +240,7 @@ class foreman_proxy_content (
         contain foreman_proxy_content::dispatch_router::hub
       } else {
         class { 'foreman_proxy_content::dispatch_router::connector':
-          host => $parent_fqdn,
+          host => $foreman_host,
           port => $qpid_router_hub_port,
         }
         contain foreman_proxy_content::dispatch_router::connector

--- a/spec/functions/foreman_proxy_content/host_from_url_spec.rb
+++ b/spec/functions/foreman_proxy_content/host_from_url_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'foreman_proxy_content::host_from_url' do
+
+  it { expect(subject).not_to eq(nil) }
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params('').and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('just a string').and_raise_error(ArgumentError) }
+
+  context 'with basic URL' do
+    let(:url) { 'https://test.example.com' }
+
+    it { is_expected.to run.with_params(url).and_return('test.example.com') }
+  end
+
+  context 'with path on the URL' do
+    let(:url) { 'https://test.example.com/api/v2/blah' }
+
+    it { is_expected.to run.with_params(url).and_return('test.example.com') }
+  end
+
+  context 'with trailing /' do
+    let(:url) { 'https://test.example.com/' }
+
+    it { is_expected.to run.with_params(url).and_return('test.example.com') }
+  end
+end


### PR DESCRIPTION
I wanted to continue working toward the number of things a user has to specify to get things working and in this case the number of things a user has to specify multiple times, via different parameters. If we take https://github.com/theforeman/forklift/blob/master/pipelines/install/04-install_proxy.yaml#L11 as an example, the user effectively specifies the Foreman server hostname 4 times in the most basic of commands to install a content proxy.