### PR TITLE
Fixes #31662: Set enable_http to ensure pub dir is deployed to Pulp v…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -288,6 +288,7 @@ class foreman_proxy_content (
       enable_deb             => $enable_pulp2_deb,
       enable_puppet          => $enable_puppet,
       enable_docker          => $enable_docker,
+      enable_http            => true,
       default_password       => $pulp_admin_password,
       messaging_transport    => 'qpid',
       messaging_auth_enabled => false,


### PR DESCRIPTION
…host

This should be cherry picked to 3.18. This affects only content proxies deployed in Katello 3.18 (or current nightly, all that changes once we go Pulp 3 only) that have `enable_puppet` set to false. The reason is this chunk of code: https://github.com/theforeman/puppet-pulp/blob/master/manifests/apache.pp#L23

