### PR TITLE
Fixes #31642 - Add container gateway support

### DIFF
--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -1,0 +1,46 @@
+# @summary Pulp Container plugin
+# @param location_prefix
+#   In the Apache configuration a location with this prefix is exposed. The
+#   version will be appended.
+# @param registry_v1_path
+#   The path beneath the location prefix to forward. This is also appended to
+#   the content base url.
+# @param registry_v2_path
+#   The path beneath the location prefix to forward. This is also appended to
+#   the content base url.
+class foreman_proxy_content::container (
+  String $location_prefix = '/pulpcore_registry',
+  String $registry_v1_path = '/v1/',
+  String $registry_v2_path = '/v2/',
+) {
+  include certs::foreman_proxy
+
+  $context = {
+    'directories'  => [
+      {
+        'provider'        => 'location',
+        'path'            => "${location_prefix}${registry_v2_path}",
+        'request_headers' => ["set SSL_CLIENT_S_DN \"admin\""],
+        'requires'        => ["expr %{SSL_CLIENT_S_DN_CN} == \"${certs::foreman_proxy::hostname}\""]
+      },
+    ],
+    'proxy_pass' => [
+      {
+        'path' => $registry_v1_path,
+        'url'  => "${foreman_proxy::real_registered_proxy_url}/container_gateway${registry_v1_path}",
+      },
+      {
+        'path' => $registry_v2_path,
+        'url'  => "${foreman_proxy::real_registered_proxy_url}/container_gateway${registry_v2_path}",
+      },
+    ],
+  }
+
+  $https_content = epp('foreman_proxy_content/container-gateway-fragment.epp', $context)
+
+  apache::vhost::fragment { 'pulp-https-container':
+    vhost    => 'pulpcore-https',
+    priority => '10',
+    content  => $https_content,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -254,6 +254,12 @@ class foreman_proxy_content (
 
   if $enable_docker {
     include pulpcore::plugin::container
+    unless $shared_with_foreman_vhost {
+      include foreman_proxy_content::container
+      class { 'foreman_proxy::plugin::container_gateway':
+        pulp_endpoint => "https://${servername}",
+      }
+    }
   }
   if $enable_file {
     class { 'pulpcore::plugin::file':

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "theforeman/foreman_proxy",
-      "version_requirement": ">= 13.0.0 < 18.0.0"
+      "version_requirement": ">= 17.1.0 < 18.0.0"
     },
     {
       "name": "katello/qpid",

--- a/spec/classes/foreman_proxy_content__container_spec.rb
+++ b/spec/classes/foreman_proxy_content__container_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe 'foreman_proxy_content::container' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      let(:pre_condition) do
+        <<-PUPPET
+        include foreman_proxy
+        PUPPET
+      end
+
+      describe 'with inherited parameters' do
+
+        it { is_expected.to compile.with_all_deps }
+        it do
+          is_expected.to contain_apache__vhost__fragment('pulp-https-container')
+            .with_vhost('pulpcore-https')
+            .with_priority('10')
+            .with_content(%r{^\s+<Location "/pulpcore_registry/v2/">$})
+            .with_content(%r{^\s+Require expr %\{SSL_CLIENT_S_DN_CN\} == "foo.example.com"$})
+            .with_content(%r{^\s+RequestHeader set SSL_CLIENT_S_DN "admin"$})
+            .with_content(%r{^\s+</Location>$})
+            .with_content(%r{^\s+ProxyPass /v1/ https://foo\.example\.com:8443/container_gateway/v1/$})
+            .with_content(%r{^\s+ProxyPass /v2/ https://foo\.example\.com:8443/container_gateway/v2/$})
+            .with_content(%r{^\s+ProxyPassReverse /v1/ https://foo\.example\.com:8443/container_gateway/v1/$})
+            .with_content(%r{^\s+ProxyPassReverse /v2/ https://foo\.example\.com:8443/container_gateway/v2/$})
+        end
+      end
+
+      describe 'with explicit parameters' do
+        let(:params) { { location_prefix: '/other_pulpcore_registry', registry_v1_path: '/vr1/', registry_v2_path: '/vr2/' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it do
+          is_expected.to contain_apache__vhost__fragment('pulp-https-container')
+            .with_vhost('pulpcore-https')
+            .with_priority('10')
+            .with_content(%r{^\s+<Location "/other_pulpcore_registry/vr2/">$})
+            .with_content(%r{^\s+Require expr %\{SSL_CLIENT_S_DN_CN\} == "foo.example.com"$})
+            .with_content(%r{^\s+RequestHeader set SSL_CLIENT_S_DN "admin"$})
+            .with_content(%r{^\s+</Location>$})
+            .with_content(%r{^\s+ProxyPass /vr1/ https://foo\.example\.com:8443/container_gateway/vr1/$})
+            .with_content(%r{^\s+ProxyPass /vr2/ https://foo\.example\.com:8443/container_gateway/vr2/$})
+            .with_content(%r{^\s+ProxyPassReverse /vr1/ https://foo\.example\.com:8443/container_gateway/vr1/$})
+            .with_content(%r{^\s+ProxyPassReverse /vr2/ https://foo\.example\.com:8443/container_gateway/vr2/$})
+        end
+      end
+    end
+  end
+end

--- a/templates/container-gateway-fragment.epp
+++ b/templates/container-gateway-fragment.epp
@@ -1,0 +1,37 @@
+<%- |
+  Array[Struct[{
+    provider => Enum['directory', 'directorymatch', 'location', 'locationmatch', 'files', 'filesmatch', 'proxy', 'proxymatch'],
+    path => String[1],
+    Optional[request_headers] => Array[String[1]],
+    Optional[requires] => Array[String[1]],
+  }]] $directories,
+  Array[Hash[String, String]] $proxy_pass = [],
+  Array[String] $misc_options = [],
+| -%>
+
+  ## Container Gateway
+<%- $directories.each |$directory| { -%>
+  <%-
+    if $directory['provider'] =~ /^(.*)match$/ {
+      $provider = $1.capitalize + 'Match'
+    } else {
+      $provider = $directory['provider'].capitalize
+    }
+  -%>
+  <<%= $provider %> "<%= $directory['path'] %>">
+    <%- if $directory['requires'] { -%>
+    <%-   $directory['requires'].each |$requires_statement| { -%>
+    Require <%= $requires_statement %>
+    <%-   } -%>
+    <%- } -%>
+    <%- if $directory['request_headers'] { -%>
+    <%-   $directory['request_headers'].each |$request_statement| { -%>
+    RequestHeader <%= $request_statement %>
+    <%-   } -%>
+    <%- } -%>
+  </<%= $provider %>>
+<% } -%>
+<% $proxy_pass.each |$proxy| { -%>
+  ProxyPass <%= $proxy['path'] %> <%= $proxy['url'] %>
+  ProxyPassReverse <%= $proxy['path'] %> <%= $proxy['url'] %>
+<% } -%>


### PR DESCRIPTION
Supports the Container Gateway smart proxy plugin by adding the proper Apache proxy configuration.

Fragment example that appears at the end of the 443 vhost:
```
  ## Container Gateway
  <Location "/pulpcore_registry/v2/">
    Require expr %{SSL_CLIENT_S_DN_CN} == "centos7-proxy-devel-3.cannolo.example.com"
    RequestHeader set SSL_CLIENT_S_DN "admin"
  </Location>
  ProxyPass /v1/ https://127.0.0.1:9090/container_gateway/v1/
  ProxyPassReverse /v1/ https://127.0.0.1:9090/container_gateway/v1/
  ProxyPass /v2/ https://127.0.0.1:9090/container_gateway/v2/
  ProxyPassReverse /v2/ https://127.0.0.1:9090/container_gateway/v2/
  SSLProxyCheckPeerCN off
  SSLProxyCheckPeerName off
```

I'm pretty new to the foreman-installer so let me know any places where I'm breaking standards.

TODO:
- [x] Add tests