### PR TITLE
Fixes #31800 - Create qdrouter inbound link for katello.agent queue

### DIFF
--- a/manifests/dispatch_router/hub.pp
+++ b/manifests/dispatch_router/hub.pp
@@ -62,6 +62,12 @@ class foreman_proxy_content::dispatch_router::hub (
     connection => 'broker',
   }
 
+  qpid::router::link_route { 'broker-katello-agent-route-in':
+    prefix     => 'katello.agent',
+    direction  => 'in',
+    connection => 'broker',
+  }
+
   qpid::router::link_route { 'broker-qmf-route-in':
     prefix     => 'qmf.',
     connection => 'broker',


### PR DESCRIPTION
This works for my client connected through a proxy rather than my Katello server directly - so should handle both cases