### PR TITLE
Group together spec tests

### DIFF
--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -9,11 +9,6 @@ describe 'foreman_proxy_content' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_package('katello-debug') }
         it { is_expected.to contain_class('foreman_proxy_content::pub_dir') }
-      end
-
-      context 'with pulpcore' do
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_class('foreman_proxy_content::pub_dir') }
         it do
           is_expected.to contain_class('pulpcore')
             .with(apache_http_vhost: 'foreman')


### PR DESCRIPTION
Since b8a699ff9b3c2e3457c3165d33217d3657bee091 pulpcore is always enabled. That means `without parameters` and `with pulpcore` are the same.