### PR TITLE
Fixes #31868: Switch to /pulp/content/ by default for clients

### DIFF
--- a/lib/puppet/provider/rhsm_reconfigure_script/rhsm_reconfigure_script.rb
+++ b/lib/puppet/provider/rhsm_reconfigure_script/rhsm_reconfigure_script.rb
@@ -99,7 +99,7 @@ Puppet::Type.type(:rhsm_reconfigure_script).provide(:rhsm_reconfigure_script) do
           --rhsm.baseurl="$BASEURL"
       else
         # rhel setup
-        BASEURL=https://$KATELLO_SERVER/pulp/repos
+        BASEURL=https://$KATELLO_SERVER/pulp/content/
 
         # Get version of RHSM
         RHSM_V="$((rpm -q --queryformat='%{VERSION}' subscription-manager 2> /dev/null || echo 0.0.0) | tail -n1 | tr . ' ')"

--- a/spec/acceptance/bootstrap_rpm_spec.rb
+++ b/spec/acceptance/bootstrap_rpm_spec.rb
@@ -66,7 +66,7 @@ describe 'bootstrap_rpm', :order => :defined do
       its(:content) { should match /full_refresh_on_yum = 1/ }
       its(:content) { should match /package_profile_on_trans = 1/ }
       its(:content) { should match /hostname = #{host_inventory['fqdn']}/ }
-      its(:content) { should match /baseurl = https:\/\/#{host_inventory['fqdn']}\/pulp\/repos/ }
+      its(:content) { should match %r{baseurl = https://#{host_inventory['fqdn']}/pulp/content/} }
       its(:content) { should match /port = 443/ }
     end
   end
@@ -153,7 +153,7 @@ describe 'bootstrap_rpm', :order => :defined do
       its(:content) { should match /full_refresh_on_yum = 1/ }
       its(:content) { should match /package_profile_on_trans = 1/ }
       its(:content) { should match /hostname = #{host_inventory['fqdn']}/ }
-      its(:content) { should match /baseurl = https:\/\/#{host_inventory['fqdn']}\/pulp\/repos/ }
+      its(:content) { should match %r{baseurl = https://#{host_inventory['fqdn']}/pulp/content/} }
       its(:content) { should match /port = 443/ }
     end
   end


### PR DESCRIPTION
With Pulp 3 present, clients should start talking to /pulp/content/
to eventually be able to drop the old Pulp 2 URLs in our reverse
proxy configuration.