### PR TITLE
Add pulpcore_django_secret_key parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,7 +113,7 @@ class foreman_proxy_content (
   Stdlib::Absolutepath $pulpcore_postgresql_ssl_key = '/etc/pki/katello/private/pulpcore-database.key',
   Stdlib::Absolutepath $pulpcore_postgresql_ssl_root_ca = '/etc/pki/tls/certs/ca-bundle.crt',
   Integer[0] $pulpcore_worker_count = $foreman_proxy_content::params::pulpcore_worker_count,
-  Optional[String] $pulpcore_django_secret_key = undef,
+  Optional[String[50]] $pulpcore_django_secret_key = undef,
 ) inherits foreman_proxy_content::params {
   include certs
   include foreman_proxy

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,6 +73,8 @@
 #                                       degradation due to I/O blocking and is not recommended in most cases. Modifying this parameter should be done
 #                                       incrementally with benchmarking at each step to determine an optimal value for your deployment.
 #
+# $pulpcore_django_secret_key::         Secret key used for cryptographic operations by Pulpcore's django runtime
+#
 class foreman_proxy_content (
   Boolean $pulpcore_mirror = false,
 
@@ -111,6 +113,7 @@ class foreman_proxy_content (
   Stdlib::Absolutepath $pulpcore_postgresql_ssl_key = '/etc/pki/katello/private/pulpcore-database.key',
   Stdlib::Absolutepath $pulpcore_postgresql_ssl_root_ca = '/etc/pki/tls/certs/ca-bundle.crt',
   Integer[0] $pulpcore_worker_count = $foreman_proxy_content::params::pulpcore_worker_count,
+  Optional[String] $pulpcore_django_secret_key = undef,
 ) inherits foreman_proxy_content::params {
   include certs
   include foreman_proxy
@@ -235,6 +238,7 @@ class foreman_proxy_content (
     postgresql_db_ssl_key     => $pulpcore_postgresql_ssl_key,
     postgresql_db_ssl_root_ca => $pulpcore_postgresql_ssl_root_ca,
     worker_count              => $pulpcore_worker_count,
+    django_secret_key         => $pulpcore_django_secret_key,
     before                    => Class['foreman_proxy::plugin::pulp'],
   }
 

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -65,6 +65,21 @@ describe 'foreman_proxy_content' do
             end
           end
         end
+
+        context 'with django_secret_key' do
+          let(:params) do
+            {
+              pulpcore_django_secret_key: 'abcdefg'
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it do
+            is_expected.to contain_class('pulpcore')
+              .with_django_secret_key('abcdefg')
+          end
+        end
       end
 
       context 'as mirror' do

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -69,7 +69,7 @@ describe 'foreman_proxy_content' do
         context 'with django_secret_key' do
           let(:params) do
             {
-              pulpcore_django_secret_key: 'abcdefg'
+              pulpcore_django_secret_key: 'randomsecretkeyfordjangowithatleast50characters123'
             }
           end
 
@@ -77,7 +77,7 @@ describe 'foreman_proxy_content' do
 
           it do
             is_expected.to contain_class('pulpcore')
-              .with_django_secret_key('abcdefg')
+              .with_django_secret_key('randomsecretkeyfordjangowithatleast50characters123')
           end
         end
       end


### PR DESCRIPTION
Currently, the pulpcore parameter `django_secret_key` is generated/cached using `extlib` inside `puppet-pulpcore`. As the parameter is not exposed here, this breaks when using multiple puppetservers.

With this PR a user can explicitly specify that parameter. If the parameter is not set, it will still use the implementation of `puppet-pulpcore` (to not break existing installs).