### PR TITLE
Allow katello/qpid 7.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "katello/qpid",
-      "version_requirement": ">= 4.5.0 < 7.0.0"
+      "version_requirement": ">= 4.5.0 < 8.0.0"
     },
     {
       "name": "katello/certs",


### PR DESCRIPTION
7.x is mostly there because it starts to use modern (current?) facts instead of legacy. There is no API change.