### PR TITLE
Fixes #32161: Set disablereuse=on and retry=0 on reverse proxy

### DIFF
--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -18,7 +18,7 @@ class foreman_proxy_content::reverse_proxy (
   Stdlib::Port $port = $foreman_proxy_content::reverse_proxy_port,
   Variant[Array[String], String, Undef] $ssl_protocol = undef,
   Hash[String, Any] $vhost_params = {},
-  Hash[String, Variant[String, Integer]] $proxy_pass_params = {},
+  Hash[String, Variant[String, Integer]] $proxy_pass_params = {'disablereuse' => 'on', 'retry' => '0'},
 ) {
   include apache
   include certs::apache

--- a/spec/classes/foreman_proxy_content__reverse_proxy_spec.rb
+++ b/spec/classes/foreman_proxy_content__reverse_proxy_spec.rb
@@ -23,7 +23,7 @@ describe 'foreman_proxy_content::reverse_proxy' do
               'path' => '/',
               'url' => "https://#{facts[:fqdn]}/",
               'reverse_urls' => ["https://#{facts[:fqdn]}/"],
-              'params' => {},
+              'params' => {'disablereuse' => 'on', 'retry' => '0'},
             }])
         end
       end
@@ -42,10 +42,10 @@ describe 'foreman_proxy_content::reverse_proxy' do
               'path' => '/',
               'url' => 'https://foreman.example.com/',
               'reverse_urls' => ['https://foreman.example.com/'],
-              'params' => {},
+              'params' => {'disablereuse' => 'on', 'retry' => '0'},
             }])
           is_expected.to contain_concat__fragment('katello-reverse-proxy-proxy')
-            .with_content(%r{^\s+ProxyPass / https://foreman\.example\.com/$})
+            .with_content(%r{^\s+ProxyPass / https://foreman\.example\.com/ disablereuse=on retry=0$})
         end
 
         describe 'with custom servername and cnames' do
@@ -74,7 +74,7 @@ describe 'foreman_proxy_content::reverse_proxy' do
         end
 
         describe 'with proxy_pass_params' do
-          let(:params) { super().merge(proxy_pass_params: {disablereuse: 'on'}) }
+          let(:params) { super().merge(proxy_pass_params: {disablereuse: 'off'}) }
 
           it { is_expected.to compile.with_all_deps }
           it do
@@ -83,10 +83,10 @@ describe 'foreman_proxy_content::reverse_proxy' do
                 'path' => '/',
                 'url' => 'https://foreman.example.com/',
                 'reverse_urls' => ['https://foreman.example.com/'],
-                'params' => {'disablereuse' => 'on'},
+                'params' => {'disablereuse' => 'off'},
               }])
             is_expected.to contain_concat__fragment('katello-reverse-proxy-proxy')
-              .with_content(%r{^\s+ProxyPass / https://foreman\.example\.com/ disablereuse=on$})
+              .with_content(%r{^\s+ProxyPass / https://foreman\.example\.com/ disablereuse=off$})
           end
         end
       end


### PR DESCRIPTION
This change aims to avoid timeouts and delays when client connection
is interrupted reverse proxying back to the Foreman server.
The reverse proxy is meant for communication back to primary Foreman
server where there are not multiple "workers" to receive a request.
This should reduce the number of clients getting 502 proxy errors
and having to be retried manually thus increasing the reliability.