### PR TITLE
Generalize Puppet certs chaining

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -14,6 +14,7 @@ fixtures:
     foreman_proxy: "https://github.com/theforeman/puppet-foreman_proxy.git"
     foreman:       "https://github.com/theforeman/puppet-foreman"
     puppet:        "https://github.com/theforeman/puppet-puppet"
+    puppetserver_foreman: "https://github.com/theforeman/puppet-puppetserver_foreman"
     tftp:          "https://github.com/theforeman/puppet-tftp"
     xinetd:        "https://github.com/puppetlabs/puppetlabs-xinetd"
     certs:         "https://github.com/theforeman/puppet-certs.git"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -294,7 +294,7 @@ class foreman_proxy_content (
     if $puppet::server and $puppet::server::foreman {
       class { 'certs::puppet':
         hostname => $certs::foreman_proxy::hostname,
-        before   => Class['foreman::puppetmaster'],
+        before   => Class['puppet::server::config'],
       }
     }
   }

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -147,7 +147,7 @@ describe 'foreman_proxy_content' do
           it { is_expected.to compile.with_all_deps }
           it do
             is_expected.to contain_class('certs::puppet')
-              .that_comes_before('Class[foreman::puppetmaster]')
+              .that_comes_before(['Class[puppet::server::config]', 'Class[puppetserver_foreman]'])
           end
         end
 


### PR DESCRIPTION
In current git master the integration code changed from foreman::puppetmaster to puppetserver_foreman. This updates the class to run before puppet::server::config since that does the actual include.  This makes it compatible with both old and new versions without relying on internal implementation details.