### PR TITLE
Refs #32338 - Move content array param to params.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,7 +113,7 @@ class foreman_proxy_content (
   Boolean $pulpcore_manage_postgresql = true,
   Stdlib::Host $pulpcore_postgresql_host = 'localhost',
   Stdlib::Port $pulpcore_postgresql_port = 5432,
-  Pulpcore::ChecksumTypes $pulpcore_allowed_content_checksums = ['sha1', 'sha224', 'sha256', 'sha384', 'sha512'],
+  Pulpcore::ChecksumTypes $pulpcore_allowed_content_checksums = $foreman_proxy_content::params::pulpcore_allowed_content_checksums,
   String $pulpcore_postgresql_user = 'pulp',
   String $pulpcore_postgresql_password = $foreman_proxy_content::params::pulpcore_postgresql_password,
   String $pulpcore_postgresql_db_name = 'pulpcore',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,8 @@ class foreman_proxy_content::params {
 
   $qpid_router_sasl_password = extlib::cache_data('foreman_cache_data', 'qpid_router_sasl_password', extlib::random_password(16))
 
+  $pulpcore_allowed_content_checksums = ['sha1', 'sha224', 'sha256', 'sha384', 'sha512']
+
   $pulpcore_postgresql_password = extlib::cache_data('pulpcore_cache_data', 'db_password', extlib::random_password(32))
   $pulpcore_worker_count        = min(8, $facts['processors']['count'])
 


### PR DESCRIPTION
Kafo bug #31565 means we can't use arrays as defaults in the file itself. It ends up being interpreted as a long string rather than an array of strings. By placing it in params.pp, it does work.

https://projects.theforeman.org/issues/31565