### PR TITLE
Set filedigest to still be compatible with SLES11

### DIFF
--- a/lib/puppet/provider/bootstrap_rpm/bootstrap_rpm.rb
+++ b/lib/puppet/provider/bootstrap_rpm/bootstrap_rpm.rb
@@ -160,6 +160,9 @@ Puppet::Type.type(:bootstrap_rpm).provide(:bootstrap_rpm) do
 
   def spec
     <<~HEREDOC
+      %global _binary_filedigest_algorithm md5
+      %global _source_filedigest_algorithm md5
+
       Name:      %{name}
       Version:   1.0
       Release:   %{release}


### PR DESCRIPTION
Previously, in the katello-certs-gen-rpm script, the filedigest
algorithm was set like this:

 --define '_source_filedigest_algorithm md5'
 --define '_binary_filedigest_algorithm md5'