### PR TITLE
Fixes #32383: Set Pulp to expect Foreman host as the client authentic…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -226,6 +226,10 @@ class foreman_proxy_content (
     $apache_https_chain = $certs::katello_server_ca_cert
   }
 
+  $api_client_auth_cn_map = Hash($foreman_proxy::trusted_hosts.map |$host| {
+      [$host, 'admin']
+  })
+
   class { 'pulpcore':
     allowed_content_checksums      => $pulpcore_allowed_content_checksums,
     allowed_import_path            => $pulpcore_allowed_import_path,
@@ -254,6 +258,7 @@ class foreman_proxy_content (
     django_secret_key              => $pulpcore_django_secret_key,
     content_service_worker_timeout => $pulpcore_content_service_worker_timeout,
     api_service_worker_timeout     => $pulpcore_api_service_worker_timeout,
+    api_client_auth_cn_map         => $api_client_auth_cn_map,
     before                         => Class['foreman_proxy::plugin::pulp'],
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,7 @@
     },
     {
       "name": "theforeman/pulpcore",
-      "version_requirement": ">= 3.3.0 < 4.0.0"
+      "version_requirement": ">= 3.4.0 < 4.0.0"
     }
   ],
   "requirements": [

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -16,6 +16,7 @@ describe 'foreman_proxy_content' do
             .with(content_service_worker_timeout: 90)
             .with(api_service_worker_timeout: 90)
             .with(allowed_content_checksums: ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512'])
+            .with(api_client_auth_cn_map: {facts[:fqdn] => 'admin'})
             .that_comes_before('Class[foreman_proxy::plugin::pulp]')
         end
 


### PR DESCRIPTION
…ating

This sets Apache to expect the client certificate to contain as the
common name the hostname of Foreman. This corresponds to using the
Foreman client certificates to talk to Pulp's API which is expected
to contain the hostname of Foreman in the certificate.