### PR TITLE
Use foreman::repo to configure repositories in acceptance

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,12 +1,5 @@
-$major = $facts['os']['release']['major']
-
-# Defaults to staging, for release, use
-# $baseurl = "https://yum.theforeman.org/releases/nightly/el${major}/x86_64/"
-$baseurl = "http://koji.katello.org/releases/yum/foreman-nightly/RHEL/${major}/x86_64/"
-
-yumrepo { 'foreman':
-  baseurl  => $baseurl,
-  gpgcheck => 0,
+class { 'foreman::repo':
+  repo => 'nightly',
 }
 
 package { 'policycoreutils':


### PR DESCRIPTION
This has the added benefit that SCL repositories are also configured if needed. It can't use staging from koji, but usually we don't depend on that anyway. It also reduces load on koji. The CDN is usually faster as well.