### PR TITLE
Include certs::foreman_proxy instead of declaring

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,9 +144,8 @@ class foreman_proxy_content (
 
   ensure_packages('katello-debug')
 
-  class { 'certs::foreman_proxy':
-    notify => Service['foreman-proxy'],
-  }
+  include certs::foreman_proxy
+  Class['certs::foreman_proxy'] ~> Service['foreman-proxy']
 
   class { 'foreman_proxy_content::bootstrap_rpm':
     rhsm_port => $rhsm_port,


### PR DESCRIPTION
This allows inclusion prior to this module while achieving the same end result.