### PR TITLE
Fixes #32529: Find latest bootstrap RPM by sorting as intenger

### DIFF
--- a/lib/puppet/provider/bootstrap_rpm/bootstrap_rpm.rb
+++ b/lib/puppet/provider/bootstrap_rpm/bootstrap_rpm.rb
@@ -149,7 +149,7 @@ Puppet::Type.type(:bootstrap_rpm).provide(:bootstrap_rpm) do
 
     return false if rpms.empty?
 
-    rpms.max_by { |name| rpm('-qp', name, "--queryformat=%{release}") }
+    rpms.max_by { |name| rpm('-qp', name, "--queryformat=%{release}")[/\d+/].to_i }
   end
 
   def mkdir(dir)

--- a/spec/acceptance/bootstrap_rpm_spec.rb
+++ b/spec/acceptance/bootstrap_rpm_spec.rb
@@ -157,4 +157,24 @@ describe 'bootstrap_rpm', :order => :defined do
       its(:content) { should match /port = 443/ }
     end
   end
+
+  context 'correctly sets latest RPM after reaching RPM release of 10' do
+    it 'applies 8 more times without error' do
+      7.times do |num|
+        apply_manifest(
+          "class { 'foreman_proxy_content::bootstrap_rpm': rhsm_port => 844#{num}, }",
+          catch_failures: true
+        )
+      end
+    end
+
+    describe file("/var/www/html/pub/katello-ca-consumer-#{host_inventory['fqdn']}-1.0-10.noarch.rpm") do
+      it { should be_file }
+    end
+
+    describe file('/var/www/html/pub/katello-ca-consumer-latest.noarch.rpm') do
+      it { should be_symlink }
+      it { should be_linked_to "/var/www/html/pub/katello-ca-consumer-#{host_inventory['fqdn']}-1.0-10.noarch.rpm" }
+    end
+  end
 end


### PR DESCRIPTION
The code that finds the maximum (latest) bootstrap RPM was doing
so via a lexical sort which resulted in incorrect ordering for
what should be latest and thus the 9th RPM was always latest. For
example, once the 10th RPM was generated the order went: 1,10,2,3 etc.

This change moves to parsing out the digits (in case there are alphabet
characters present from the dist) in the release, converting to
integers and then sorting.