### PR TITLE
Fixes #32553 - Remove md5 from allowed content types

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,7 @@ class foreman_proxy_content::params {
 
   $qpid_router_sasl_password = extlib::cache_data('foreman_cache_data', 'qpid_router_sasl_password', extlib::random_password(16))
 
-  $pulpcore_allowed_content_checksums = ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']
+  $pulpcore_allowed_content_checksums = ['sha1', 'sha224', 'sha256', 'sha384', 'sha512']
 
   $pulpcore_postgresql_password = extlib::cache_data('pulpcore_cache_data', 'db_password', extlib::random_password(32))
   $pulpcore_worker_count        = min(8, $facts['processors']['count'])

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -15,7 +15,7 @@ describe 'foreman_proxy_content' do
             .with(apache_https_vhost: 'foreman-ssl')
             .with(content_service_worker_timeout: 90)
             .with(api_service_worker_timeout: 90)
-            .with(allowed_content_checksums: ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512'])
+            .with(allowed_content_checksums: ['sha1', 'sha224', 'sha256', 'sha384', 'sha512'])
             .with(api_client_auth_cn_map: {facts[:fqdn] => 'admin'})
             .that_comes_before('Class[foreman_proxy::plugin::pulp]')
         end


### PR DESCRIPTION
Previously we had added md5 to maintain md5 across upgrades
such that the upgrade would pass, but it turns out pulpcore 3.11
includes a migration which would handle this for us, if we were
running the db migration before collectstatic