### PR TITLE
Fixes #32567: Ensure bootstrap RPM symlink exists

### DIFF
--- a/lib/puppet/type/bootstrap_rpm.rb
+++ b/lib/puppet/type/bootstrap_rpm.rb
@@ -15,8 +15,20 @@ Puppet::Type.newtype(:bootstrap_rpm) do
     desc "Location on disk to deploy the bootstrap RPM"
   end
 
-  newparam(:symlink) do
+  newproperty(:symlink) do
     desc "Name of the symlink to link the most recent RPM to"
+
+    def latest_rpm
+      provider.latest_rpm
+    end
+
+    def should_to_s(newvalue)
+      self.class.format_value_for_display(latest_rpm)
+    end
+
+    def insync?(is)
+      is == latest_rpm
+    end
   end
 
   autorequire(:file) do

--- a/spec/acceptance/bootstrap_rpm_spec.rb
+++ b/spec/acceptance/bootstrap_rpm_spec.rb
@@ -32,6 +32,10 @@ describe 'bootstrap_rpm', :order => :defined do
       it { should be_file }
     end
 
+    describe file("/var/www/html/pub/katello-ca-consumer-#{host_inventory['fqdn']}-1.0-2.noarch.rpm") do
+      it { should_not exist }
+    end
+
     describe file('/var/www/html/pub/katello-ca-consumer-latest.noarch.rpm') do
       it { should be_symlink }
       it { should be_linked_to "/var/www/html/pub/katello-ca-consumer-#{host_inventory['fqdn']}-1.0-1.noarch.rpm" }
@@ -68,6 +72,26 @@ describe 'bootstrap_rpm', :order => :defined do
       its(:content) { should match /hostname = #{host_inventory['fqdn']}/ }
       its(:content) { should match %r{baseurl = https://#{host_inventory['fqdn']}/pulp/content/} }
       its(:content) { should match /port = 443/ }
+    end
+  end
+
+  context 'ensure symlink is present if deleted' do
+    it 'removes symlink and re-applies the manifest' do
+      apply_manifest("exec { '/bin/unlink /var/www/html/pub/katello-ca-consumer-latest.noarch.rpm': }", catch_failures: true)
+      apply_manifest("class { 'foreman_proxy_content::bootstrap_rpm': }", catch_failures: true)
+    end
+
+    describe file("/var/www/html/pub/katello-ca-consumer-#{host_inventory['fqdn']}-1.0-1.noarch.rpm") do
+      it { should be_file }
+    end
+
+    describe file("/var/www/html/pub/katello-ca-consumer-#{host_inventory['fqdn']}-1.0-2.noarch.rpm") do
+      it { should_not exist }
+    end
+
+    describe file('/var/www/html/pub/katello-ca-consumer-latest.noarch.rpm') do
+      it { should be_symlink }
+      it { should be_linked_to "/var/www/html/pub/katello-ca-consumer-#{host_inventory['fqdn']}-1.0-1.noarch.rpm" }
     end
   end
 
@@ -159,7 +183,7 @@ describe 'bootstrap_rpm', :order => :defined do
   end
 
   context 'correctly sets latest RPM after reaching RPM release of 10' do
-    it 'applies 8 more times without error' do
+    it 'applies 7 more times without error' do
       7.times do |num|
         apply_manifest(
           "class { 'foreman_proxy_content::bootstrap_rpm': rhsm_port => 844#{num}, }",


### PR DESCRIPTION
Adds a separate existence check for the symlink to ensure it exists
and points at the latest RPM. This ensures that if something removes
the symlink on the system tne next puppet run will put the symlink
back in place. Prior to this the symlink could be removed from the
system and the only way Puppet would put it back was if the RPM itself
got updated.