### PR TITLE
Add explicit dependency on puppet/trusted_ca

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,6 +17,10 @@
       "version_requirement": ">= 3.0.0 < 6.0.0"
     },
     {
+      "name": "puppet/trusted_ca",
+      "version_requirement": ">= 2.0.0 < 4.0.0"
+    },
+    {
       "name": "puppetlabs/apache",
       "version_requirement": ">= 2.0.0 < 7.0.0"
     },


### PR DESCRIPTION
In 7bf101dc5507c90936b9e6169b91848ef106fe0f this module started to use trusted_ca directly but didn't declare the dependency. This was ok since theforeman/certs still pulled it in (despite not using it). Adding it here allows theforeman/certs to drop it.

Fixes: 7bf101dc5507c90936b9e6169b91848ef106fe0f