### PR TITLE
Unpin camptocamp/systemd in fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -27,9 +27,7 @@ fixtures:
     selinux_core:
       repo: "https://github.com/puppetlabs/puppetlabs-selinux_core"
       puppet_version: ">= 6.0.0"
-    systemd:
-      repo: 'https://github.com/camptocamp/puppet-systemd'
-      ref: '2.12.0' 
+    systemd:       'https://github.com/camptocamp/puppet-systemd'
     yumrepo_core:
       repo: "https://github.com/puppetlabs/puppetlabs-yumrepo_core"
       puppet_version: ">= 6.0.0"


### PR DESCRIPTION
Now that all dependent modules are updated to version 3, there's no more need for this version pin and actually causes cyclic dependencies.