### PR TITLE
Mark compatible with puppet/trusted_ca 4.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppet/trusted_ca",
-      "version_requirement": ">= 2.0.0 < 4.0.0"
+      "version_requirement": ">= 2.0.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/apache",


### PR DESCRIPTION
In 0302b102786178685528cce7b94729ac44688d67 this dependency was added as a direct copy of what was in the certs module, but by now version 4 has been released and is compatible.