### PR TITLE
Fixes #32700: Only capture bootstrap RPMs by name

### DIFF
--- a/lib/puppet/provider/bootstrap_rpm/bootstrap_rpm.rb
+++ b/lib/puppet/provider/bootstrap_rpm/bootstrap_rpm.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:bootstrap_rpm).provide(:bootstrap_rpm) do
   end
 
   def latest_rpm
-    rpms = Dir.glob("#{resource[:dest]}/*.noarch.rpm")
+    rpms = Dir.glob("#{resource[:dest]}/#{resource[:name]}*.noarch.rpm")
     rpms = rpms.reject { |rpm| rpm.end_with?("latest.noarch.rpm") }
 
     return false if rpms.empty?


### PR DESCRIPTION
If a user puts other RPMs in the `/pub` directory this can break the resolution of the consumer RPM when calculating latest.