### PR TITLE
Set client_authentication on foreman_proxy::plugin::pulp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -293,11 +293,12 @@ class foreman_proxy_content (
   include pulpcore::plugin::certguard # Required to be present by Katello when syncing a content proxy
 
   class { 'foreman_proxy::plugin::pulp':
-    pulpcore_enabled     => true,
-    pulpcore_mirror      => $pulpcore_mirror,
-    pulpcore_api_url     => "https://${servername}",
-    pulpcore_content_url => "https://${servername}${pulpcore::apache::content_path}",
-    require              => Class['pulpcore'],
+    pulpcore_enabled      => true,
+    pulpcore_mirror       => $pulpcore_mirror,
+    pulpcore_api_url      => "https://${servername}",
+    pulpcore_content_url  => "https://${servername}${pulpcore::apache::content_path}",
+    client_authentication => ['client_certificate'],
+    require               => Class['pulpcore'],
   }
 
   if $puppet {

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "theforeman/foreman_proxy",
-      "version_requirement": ">= 18.0.0 < 20.0.0"
+      "version_requirement": ">= 19.0.0 < 20.0.0"
     },
     {
       "name": "katello/qpid",


### PR DESCRIPTION
Requires https://github.com/theforeman/puppet-foreman_proxy/pull/682 and a version bump in the metadata