### PR TITLE
Allow to deploy reverse proxy on multiple ports

### DIFF
--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -5,7 +5,7 @@
 # @param url
 #   The URL to forward to
 # @param port
-#   The port to listen on
+#   Port or Array of ports to listen on. One virtual host will be created per port.
 # @param ssl_protocol
 #   The ssl protocol(s) to accept
 # @param vhost_params
@@ -15,7 +15,7 @@
 class foreman_proxy_content::reverse_proxy (
   Stdlib::Unixpath $path = '/',
   Stdlib::Httpurl $url = "${foreman_proxy_content::foreman_url}/",
-  Stdlib::Port $port = $foreman_proxy_content::reverse_proxy_port,
+  Enum[Stdlib::Port, Array[Stdlib::Port, 1]] $ports = [$foreman_proxy_content::reverse_proxy_port],
   Variant[Array[String], String, Undef] $ssl_protocol = undef,
   Hash[String, Any] $vhost_params = {},
   Hash[String, Variant[String, Integer]] $proxy_pass_params = {'disablereuse' => 'on', 'retry' => '0'},
@@ -26,43 +26,57 @@ class foreman_proxy_content::reverse_proxy (
 
   Class['certs', 'certs::ca', 'certs::apache', 'certs::foreman_proxy'] ~> Class['apache::service']
 
-  apache::vhost { 'katello-reverse-proxy':
-    servername             => $certs::apache::hostname,
-    aliases                => $certs::apache::cname,
-    port                   => $port,
-    docroot                => '/var/www/',
-    priority               => '28',
-    ssl_options            => ['+StdEnvVars', '+ExportCertData', '+FakeBasicAuth'],
-    ssl                    => true,
-    ssl_proxyengine        => true,
-    ssl_proxy_ca_cert      => $certs::ca_cert,
-    ssl_proxy_machine_cert => $certs::foreman_proxy::foreman_proxy_ssl_client_bundle,
-    ssl_cert               => $certs::apache::apache_cert,
-    ssl_key                => $certs::apache::apache_key,
-    ssl_chain              => $certs::katello_server_ca_cert,
-    ssl_ca                 => $certs::ca_cert,
-    ssl_verify_client      => 'optional',
-    ssl_verify_depth       => 10,
-    ssl_protocol           => $ssl_protocol,
-    request_headers        => ['set X_RHSM_SSL_CLIENT_CERT "%{SSL_CLIENT_CERT}s"'],
-    proxy_pass             => [
-      {
-        'path'         => $path,
-        'url'          => $url,
-        'reverse_urls' => [$url],
-        'params'       => $proxy_pass_params,
-      }
-    ],
-    error_documents        => [
-      {
-        'error_code' => '500',
-        'document'   => '\'{"displayMessage": "Internal error, contact administrator", "errors": ["Internal error, contact administrator"], "status": "500" }\''
-      },
-      {
-        'error_code' => '503',
-        'document'   => '\'{"displayMessage": "Service unavailable or restarting, try later", "errors": ["Service unavailable or restarting, try later"], "status": "503" }\''
-      },
-    ],
-    *                      => $vhost_params,
+  $vhost_name = "katello-proxy-content"
+  $ports = $port ? {
+    Array        => $port,
+    Stdlib::Port => [$port],
+    default      => ['8443'],
+  }
+
+  $ports.each |Stdlib::Port $current_port| {
+    apache::vhost { "${vhost_name}:${current_port}":
+      servername             => $certs::apache::hostname,
+      aliases                => $certs::apache::cname,
+      port                   => $current_port,
+      docroot                => '/var/www/',
+      priority               => '28',
+      ssl_options            => ['+StdEnvVars', '+ExportCertData', '+FakeBasicAuth'],
+      ssl                    => true,
+      ssl_proxyengine        => true,
+      ssl_proxy_ca_cert      => $certs::ca_cert,
+      ssl_proxy_machine_cert => $certs::foreman_proxy::foreman_proxy_ssl_client_bundle,
+      ssl_cert               => $certs::apache::apache_cert,
+      ssl_key                => $certs::apache::apache_key,
+      ssl_chain              => $certs::katello_server_ca_cert,
+      ssl_ca                 => $certs::ca_cert,
+      ssl_verify_client      => 'optional',
+      ssl_verify_depth       => 10,
+      ssl_protocol           => $ssl_protocol,
+      request_headers        => ['set X_RHSM_SSL_CLIENT_CERT "%{SSL_CLIENT_CERT}s"'],
+      error_documents        => [
+        {
+          'error_code' => '500',
+          'document'   => '\'{"displayMessage": "Internal error, contact administrator", "errors": ["Internal error, contact administrator"], "status": "500" }\''
+        },
+        {
+          'error_code' => '503',
+          'document'   => '\'{"displayMessage": "Service unavailable or restarting, try later", "errors": ["Service unavailable or restarting, try later"], "status": "503" }\''
+        },
+      ],
+      *                      => $vhost_params,
+    } ~>
+    apache::vhost::fragment { "katello-reverse-proxy:${current_port}":
+      vhost   => "${vhost_name}:${current_port}",
+      content => epp('foreman_proxy_content/apache-fragment.epp', {
+        'proxy_pass' => [
+          {
+            'path'         => $path,
+            'url'          => $url,
+            'reverse_urls' => [$url],
+            'params'       => $proxy_pass_params,
+          }
+        ]
+      }),
+    }
   }
 }

--- a/templates/apache-fragment.epp
+++ b/templates/apache-fragment.epp
@@ -1,0 +1,60 @@
+<%- |
+  Array[Struct[{
+    provider => Enum['directory', 'directorymatch', 'location', 'locationmatch', 'files', 'filesmatch', 'proxy', 'proxymatch'],
+    path => String[1],
+    Optional[options] => Array[String[1]],
+    Optional[allow_override] => Array[String[1]],
+    Optional[request_headers] => Array[String[1]],
+    Optional[proxy_pass] => Array[Struct[{
+      url => String[1],
+      Optional[params] => Hash[String, Variant[String, Integer]],
+      Optional[reverse_urls] => Array[String[1]],
+    }]],
+  }]] $directories,
+  Array[Hash[String, String]] $proxy_pass = [],
+| -%>
+<%- $directories.each |$directory| { -%>
+
+  <%-
+    if $directory['provider'] =~ /^(.*)match$/ {
+      $provider = $1.capitalize + 'Match'
+    } else {
+      $provider = $directory['provider'].capitalize
+    }
+  -%>
+  <<%= $provider %> "<%= $directory['path'] %>">
+    <%- if $directory['options'] { -%>
+    Options <%= $directory['options'].join(' ') %>
+    <%- } -%>
+    <%- if $directory['allow_override'] { -%>
+    AllowOverride <%= $directory['allow_override'].join(' ') %>
+    <%- } elsif $provider == 'Directory' { -%>
+    AllowOverride None
+    <%- } -%>
+    <%- if $directory['request_headers'] { -%>
+    <%-   $directory['request_headers'].each |$request_statement| { -%>
+    RequestHeader <%= $request_statement %>
+    <%-   } -%>
+    <%- } -%>
+    <%- if $directory['proxy_pass'] and $provider in ['Location', 'LocationMatch'] { -%>
+    <%-   $directory['proxy_pass'].each |$proxy| { -%>
+    ProxyPass <%= $proxy['url'] -%>
+    <%-     if $proxy['params'] { -%>
+    <%-       $proxy['params'].keys.sort.each |$key| { -%> <%= ' ' %><%= $key %>=<%= $proxy['params'][$key] -%><%- } -%>
+    <%-     } %>
+    <%-     if $proxy['reverse_urls'] { -%>
+    <%-       $proxy['reverse_urls'].each |$reverse_url| { -%>
+    ProxyPassReverse <%= $reverse_url %>
+    <%-       } -%>
+    <%-     } else { -%>
+    ProxyPassReverse <%= $proxy['url'] %>
+    <%-     } -%>
+    <%-   } -%>
+    <%- } -%>
+  </<%= $provider %>>
+<% } -%>
+<% $proxy_pass.each |$proxy| { -%>
+
+  ProxyPass <%= $proxy['path'] %> <%= $proxy['url'] %>
+  ProxyPassReverse <%= $proxy['path'] %> <%= $proxy['url'] %>
+<% } -%>


### PR DESCRIPTION
The reverse proxy will need to listen on both 443 and 8443 to support new clients using 443 by default and migrating existing clients from 8443 to 443