### PR TITLE
Move more parameters from params.pp to init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,7 +122,7 @@ class foreman_proxy_content (
   Boolean $pulpcore_manage_postgresql = true,
   Stdlib::Host $pulpcore_postgresql_host = 'localhost',
   Stdlib::Port $pulpcore_postgresql_port = 5432,
-  Pulpcore::ChecksumTypes $pulpcore_allowed_content_checksums = $foreman_proxy_content::params::pulpcore_allowed_content_checksums,
+  Pulpcore::ChecksumTypes $pulpcore_allowed_content_checksums = ['sha1', 'sha224', 'sha256', 'sha384', 'sha512'],
   String $pulpcore_postgresql_user = 'pulp',
   String $pulpcore_postgresql_password = $foreman_proxy_content::params::pulpcore_postgresql_password,
   String $pulpcore_postgresql_db_name = 'pulpcore',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -132,10 +132,10 @@ class foreman_proxy_content (
   Stdlib::Absolutepath $pulpcore_postgresql_ssl_key = '/etc/pki/katello/private/pulpcore-database.key',
   Stdlib::Absolutepath $pulpcore_postgresql_ssl_root_ca = '/etc/pki/tls/certs/ca-bundle.crt',
   Integer[0] $pulpcore_worker_count = $foreman_proxy_content::params::pulpcore_worker_count,
-  Boolean $pulpcore_use_rq_tasking_system = $foreman_proxy_content::params::pulpcore_use_rq_tasking_system,
+  Boolean $pulpcore_use_rq_tasking_system = false,
   Optional[String[50]] $pulpcore_django_secret_key = undef,
-  Integer[0] $pulpcore_content_service_worker_timeout = $foreman_proxy_content::params::pulpcore_content_service_worker_timeout,
-  Integer[0] $pulpcore_api_service_worker_timeout = $foreman_proxy_content::params::pulpcore_api_service_worker_timeout,
+  Integer[0] $pulpcore_content_service_worker_timeout = 90,
+  Integer[0] $pulpcore_api_service_worker_timeout = 90,
   Boolean $pulpcore_cache_enabled = false,
   Optional[Variant[Integer[1], Enum['None']]] $pulpcore_cache_expires_ttl = undef,
 ) inherits foreman_proxy_content::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,8 +5,6 @@ class foreman_proxy_content::params {
 
   $qpid_router_sasl_password = extlib::cache_data('foreman_cache_data', 'qpid_router_sasl_password', extlib::random_password(16))
 
-  $pulpcore_allowed_content_checksums = ['sha1', 'sha224', 'sha256', 'sha384', 'sha512']
-
   $pulpcore_postgresql_password   = extlib::cache_data('pulpcore_cache_data', 'db_password', extlib::random_password(32))
   $pulpcore_worker_count          = min(8, $facts['processors']['count'])
   $pulpcore_use_rq_tasking_system = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,10 +5,6 @@ class foreman_proxy_content::params {
 
   $qpid_router_sasl_password = extlib::cache_data('foreman_cache_data', 'qpid_router_sasl_password', extlib::random_password(16))
 
-  $pulpcore_postgresql_password   = extlib::cache_data('pulpcore_cache_data', 'db_password', extlib::random_password(32))
-  $pulpcore_worker_count          = min(8, $facts['processors']['count'])
-  $pulpcore_use_rq_tasking_system = false
-
-  $pulpcore_content_service_worker_timeout = 90
-  $pulpcore_api_service_worker_timeout     = 90
+  $pulpcore_postgresql_password = extlib::cache_data('pulpcore_cache_data', 'db_password', extlib::random_password(32))
+  $pulpcore_worker_count = min(8, $facts['processors']['count'])
 }


### PR DESCRIPTION
See individual commits for details. These parameters do not have to be defined in params.pp. Having them in init.pp increases readability and maintainability.