### PR TITLE
Dynamically determine if Puppet should be included

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@
 #
 # === Advanced parameters:
 #
-# $puppet::                                    Enable puppet
+# $puppet::                                    Enable puppet. If undef, it will try to detect this automatically.
 #
 # $reverse_proxy::                             Add reverse proxy to the parent
 #
@@ -95,7 +95,7 @@
 class foreman_proxy_content (
   Boolean $pulpcore_mirror = false,
 
-  Boolean $puppet = true,
+  Optional[Boolean] $puppet = undef,
 
   Boolean $reverse_proxy = false,
   Stdlib::Port $reverse_proxy_port = 8443,
@@ -316,7 +316,8 @@ class foreman_proxy_content (
     require               => Class['pulpcore'],
   }
 
-  if $puppet {
+  # classes is set by Kafo
+  if pick($puppet, defined(Class['puppet']) or 'puppet' in lookup('classes', Array, undef, [])) {
     # We can't pull the certs out to the top level, because of how it gets the default
     # parameter values from the main certs class.  Kafo can't handle that case, so
     # it remains here for now.


### PR DESCRIPTION
This changes the type to Optional[Boolean]. If it's not explicitly set, some heuristics are used.

It first looks at if the class is already declared, which means it's safe to include it (essentially a noop). This depends on the compilation order.

In order to depend less on the compilation order, it looks up the key `classes` in Hiera. This key is set by Kafo and means it will be included eventually. That means it's safe to include as well.

Users who use this module directly (without Kafo) and use the Hiera `classes` key should set the boolean explicitly.