### PR TITLE
Configure RHSM url in Foreman Proxy's Pulp plugin

### DIFF
--- a/lib/puppet/provider/rhsm_reconfigure_script/rhsm_reconfigure_script.rb
+++ b/lib/puppet/provider/rhsm_reconfigure_script/rhsm_reconfigure_script.rb
@@ -42,7 +42,7 @@ Puppet::Type.type(:rhsm_reconfigure_script).provide(:rhsm_reconfigure_script) do
       KATELLO_DEFAULT_CA_CERT=<%= resource[:default_ca_name] %>.pem
 
       CERT_DIR=/etc/rhsm/ca
-      PREFIX=/rhsm
+      PREFIX=<%= resource[:rhsm_path] %>
       CFG=/etc/rhsm/rhsm.conf
       CFG_BACKUP=$CFG.kat-backup
       CA_TRUST_ANCHORS=/etc/pki/ca-trust/source/anchors

--- a/lib/puppet/type/rhsm_reconfigure_script.rb
+++ b/lib/puppet/type/rhsm_reconfigure_script.rb
@@ -31,6 +31,11 @@ Puppet::Type.newtype(:rhsm_reconfigure_script) do
     desc "Port that RHSM should be configured to talk to"
   end
 
+  newparam(:rhsm_path) do
+    desc "Path that RHSM should be configured to talk to"
+    defaultto '/rhsm'
+  end
+
   autorequire(:file) do
     [
       self[:server_ca_cert],

--- a/manifests/bootstrap_rpm.pp
+++ b/manifests/bootstrap_rpm.pp
@@ -4,6 +4,7 @@
 class foreman_proxy_content::bootstrap_rpm (
   Stdlib::Fqdn $rhsm_hostname = $facts['networking']['fqdn'],
   Stdlib::Port $rhsm_port = 443,
+  Pattern[/\A(\/[a-zA-Z0-9]+)+(\/)?\z/] $rhsm_path = '/rhsm',
   Stdlib::Absolutepath $rpm_serve_dir = '/var/www/html/pub',
 ) {
   include certs
@@ -54,6 +55,7 @@ class foreman_proxy_content::bootstrap_rpm (
     server_ca_name  => $server_ca_name,
     rhsm_hostname   => $rhsm_hostname,
     rhsm_port       => $rhsm_port,
+    rhsm_path       => $rhsm_path,
   }
 
   bootstrap_rpm { $bootstrap_rpm_name:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,10 +165,6 @@ class foreman_proxy_content (
   include certs::foreman_proxy
   Class['certs::foreman_proxy'] ~> Service['foreman-proxy']
 
-  class { 'foreman_proxy_content::bootstrap_rpm':
-    rhsm_port => $rhsm_port,
-  }
-
   if $reverse_proxy_real {
     class { 'foreman_proxy_content::reverse_proxy':
       url  => "${foreman_url}/",
@@ -328,6 +324,11 @@ class foreman_proxy_content (
     pulpcore_content_url  => "https://${servername}${pulpcore::apache::content_path}",
     client_authentication => ['client_certificate'],
     require               => Class['pulpcore'],
+  }
+
+  class { 'foreman_proxy_content::bootstrap_rpm':
+    rhsm_hostname => $servername,
+    rhsm_port     => $rhsm_port,
   }
 
   if $puppet {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -155,6 +155,7 @@ class foreman_proxy_content (
   # TODO: doesn't allow deploying a Pulp non-mirror without Foreman
   $shared_with_foreman_vhost = !$pulpcore_mirror
 
+  $rhsm_path = '/rhsm'
   $rhsm_port = $reverse_proxy_real ? {
     true  => $reverse_proxy_port,
     false => 443
@@ -317,18 +318,22 @@ class foreman_proxy_content (
   }
   include pulpcore::plugin::certguard # Required to be present by Katello when syncing a content proxy
 
+  $rhsm_url = "https://${servername}:${rhsm_port}${rhsm_path}"
+
   class { 'foreman_proxy::plugin::pulp':
     pulpcore_enabled      => true,
     pulpcore_mirror       => $pulpcore_mirror,
     pulpcore_api_url      => "https://${servername}",
     pulpcore_content_url  => "https://${servername}${pulpcore::apache::content_path}",
     client_authentication => ['client_certificate'],
+    rhsm_url              => $rhsm_url,
     require               => Class['pulpcore'],
   }
 
   class { 'foreman_proxy_content::bootstrap_rpm':
     rhsm_hostname => $servername,
     rhsm_port     => $rhsm_port,
+    rhsm_path     => $rhsm_path,
   }
 
   if $puppet {

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "theforeman/foreman_proxy",
-      "version_requirement": ">= 19.0.0 < 20.0.0"
+      "version_requirement": ">= 19.1.0 < 20.0.0"
     },
     {
       "name": "katello/qpid",

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -20,6 +20,11 @@ describe 'foreman_proxy_content' do
             .that_comes_before('Class[foreman_proxy::plugin::pulp]')
         end
 
+        it do
+          is_expected.to contain_class('foreman_proxy::plugin::pulp')
+            .with_rhsm_url("https://#{facts[:fqdn]}:443/rhsm")
+        end
+
         context 'with custom service worker timeouts' do
           let(:params) do
             {
@@ -130,6 +135,10 @@ describe 'foreman_proxy_content' do
             .with(apache_http_vhost: true)
             .with(apache_https_vhost: true)
             .that_comes_before('Class[foreman_proxy::plugin::pulp]')
+        end
+        it do
+          is_expected.to contain_class('foreman_proxy::plugin::pulp')
+            .with_rhsm_url("https://#{facts[:fqdn]}:8443/rhsm")
         end
         it do
           is_expected.to contain_class('foreman_proxy_content::reverse_proxy')


### PR DESCRIPTION
Requires https://github.com/theforeman/puppet-foreman_proxy/pull/700