### PR TITLE
Fixes #33863 - Deploy RHSM proxy vhost on 443 and attach Pulpcore configuration to it

### DIFF
--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -8,10 +8,13 @@
 # @param registry_v2_path
 #   The path beneath the location prefix to forward. This is also appended to
 #   the content base url.
+# @param pulpcore_https_vhost
+#   The name of the Apache https vhost for Pulpcore
 class foreman_proxy_content::container (
   String $location_prefix = '/pulpcore_registry',
   String $registry_v1_path = '/v1/',
   String $registry_v2_path = '/v2/',
+  String $pulpcore_https_vhost = 'pulpcore-https',
 ) {
   include certs::foreman_proxy
 
@@ -39,7 +42,7 @@ class foreman_proxy_content::container (
   $https_content = epp('foreman_proxy_content/container-gateway-fragment.epp', $context)
 
   apache::vhost::fragment { 'pulp-https-container':
-    vhost    => 'pulpcore-https',
+    vhost    => $pulpcore_https_vhost,
     priority => '10',
     content  => $https_content,
   }

--- a/spec/classes/foreman_proxy_content__container_spec.rb
+++ b/spec/classes/foreman_proxy_content__container_spec.rb
@@ -29,12 +29,12 @@ describe 'foreman_proxy_content::container' do
       end
 
       describe 'with explicit parameters' do
-        let(:params) { { location_prefix: '/other_pulpcore_registry', registry_v1_path: '/vr1/', registry_v2_path: '/vr2/' } }
+        let(:params) { { location_prefix: '/other_pulpcore_registry', registry_v1_path: '/vr1/', registry_v2_path: '/vr2/', pulpcore_https_vhost: 'rhsm-pulpcore-reverse-proxy-443' } }
 
         it { is_expected.to compile.with_all_deps }
         it do
           is_expected.to contain_apache__vhost__fragment('pulp-https-container')
-            .with_vhost('pulpcore-https')
+            .with_vhost('rhsm-pulpcore-reverse-proxy-443')
             .with_priority('10')
             .with_content(%r{^\s+<Location "/other_pulpcore_registry/vr2/">$})
             .with_content(%r{^\s+Require expr %\{SSL_CLIENT_S_DN_CN\} == "foo.example.com"$})

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -133,17 +133,26 @@ describe 'foreman_proxy_content' do
         it do
           is_expected.to contain_class('pulpcore')
             .with(apache_http_vhost: true)
-            .with(apache_https_vhost: true)
+            .with(apache_https_vhost: 'rhsm-pulpcore-https-443')
             .that_comes_before('Class[foreman_proxy::plugin::pulp]')
         end
         it do
           is_expected.to contain_class('foreman_proxy::plugin::pulp')
-            .with_rhsm_url("https://#{facts[:fqdn]}:8443/rhsm")
+            .with_rhsm_url("https://#{facts[:fqdn]}:443/rhsm")
         end
         it do
-          is_expected.to contain_class('foreman_proxy_content::reverse_proxy')
+          is_expected.to contain_foreman_proxy_content__reverse_proxy('rhsm-pulpcore-https-8443')
             .with(path: '/')
             .with(port: 8443)
+            .with(priority: '10')
+            .that_comes_before('Class[pulpcore::apache]')
+        end
+        it do
+          is_expected.to contain_foreman_proxy_content__reverse_proxy('rhsm-pulpcore-https-443')
+            .with(path: '/rhsm')
+            .with(port: 443)
+            .with(priority: '10')
+            .that_comes_before('Class[pulpcore::apache]')
         end
         it do
           is_expected.to contain_pulpcore__apache__fragment('gpg_key_proxy')

--- a/spec/defines/foreman_proxy_content__reverse_proxy_spec.rb
+++ b/spec/defines/foreman_proxy_content__reverse_proxy_spec.rb
@@ -4,8 +4,9 @@ describe 'foreman_proxy_content::reverse_proxy' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
+      let(:title) { 'my-reverse-proxy' }
 
-      describe 'with inherited parameters' do
+      context 'with inherited parameters' do
 
         let(:pre_condition) do
           <<-PUPPET
@@ -15,7 +16,7 @@ describe 'foreman_proxy_content::reverse_proxy' do
 
         it { is_expected.to compile.with_all_deps }
         it do
-          is_expected.to contain_apache__vhost('katello-reverse-proxy')
+          is_expected.to contain_apache__vhost('my-reverse-proxy')
             .with_servername(facts[:fqdn])
             .with_aliases([])
             .with_port(8443)
@@ -28,12 +29,13 @@ describe 'foreman_proxy_content::reverse_proxy' do
         end
       end
 
-      describe 'with explicit parameters' do
+      context 'with explicit parameters' do
         let(:params) { { url: 'https://foreman.example.com/', port: 443 } }
+        let(:title) { 'katello-reverse-proxy-443' }
 
         it { is_expected.to compile.with_all_deps }
         it do
-          is_expected.to contain_apache__vhost('katello-reverse-proxy')
+          is_expected.to contain_apache__vhost('katello-reverse-proxy-443')
             .with_servername('foo.example.com')
             .with_aliases([])
             .with_port(443)
@@ -44,11 +46,11 @@ describe 'foreman_proxy_content::reverse_proxy' do
               'reverse_urls' => ['https://foreman.example.com/'],
               'params' => {'disablereuse' => 'on', 'retry' => '0'},
             }])
-          is_expected.to contain_concat__fragment('katello-reverse-proxy-proxy')
+          is_expected.to contain_concat__fragment('katello-reverse-proxy-443-proxy')
             .with_content(%r{^\s+ProxyPass / https://foreman\.example\.com/ disablereuse=on retry=0$})
         end
 
-        describe 'with custom servername and cnames' do
+        context 'with custom servername and cnames' do
           let(:pre_condition) do
             <<-PUPPET
             class { 'certs::apache':
@@ -57,6 +59,7 @@ describe 'foreman_proxy_content::reverse_proxy' do
             }
             PUPPET
           end
+          let(:title) { 'katello-reverse-proxy' }
 
           it { is_expected.to compile.with_all_deps }
           it do
@@ -66,15 +69,17 @@ describe 'foreman_proxy_content::reverse_proxy' do
           end
         end
 
-        describe 'with vhost_params' do
+        context 'with vhost_params' do
           let(:params) { super().merge(vhost_params: {keepalive: 'on'}) }
+          let(:title) { 'katello-reverse-proxy' }
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_apache__vhost('katello-reverse-proxy').with_keepalive('on') }
         end
 
-        describe 'with proxy_pass_params' do
+        context 'with proxy_pass_params' do
           let(:params) { super().merge(proxy_pass_params: {disablereuse: 'off'}) }
+          let(:title) { 'katello-reverse-proxy' }
 
           it { is_expected.to compile.with_all_deps }
           it do


### PR DESCRIPTION
Builds upon #384 

The previously attempted approach of defining the RHSM ReverseProxy configuration as a template and attaching that to the existing Pulpcore vhost proved rather unwieldy.

This returns to a previous approach I had in mind, which is to deploy a separate vhost in puppet-FPC and configure Pulpcore to attach its apache configuration to it (for HTTPS only, while HTTP remains configured as before, although it could be brought in here additionally).

In the Katello scenario, this approach is already utilized with Pulpcore attaching its configuration to Foreman's vhosts (for both HTTP and HTTPS).

The advantages of doing it this way for Pulpcore HTTPS to my mind are:

1. Closer to the existing approach for Katello scenario
2. It makes more logical and architectural sense for the higher level module (puppet-FPC) to deploy the vhost while the lower level module (puppet-pulpcore) attaches additional configuration to it. **This is a step towards a more modular architecture where `/rhsm` proxying does not depend on the presence of Pulpcore, and suggests that other child classes can follow this pattern in the future if needed.**
3. Deploying separate vhosts on a per port basis is supported per Apache documentation at https://httpd.apache.org/docs/2.4/vhosts/examples.html#port
4. As currently written this approach allows for the current vhost on 8443 by default to remain as is, while the newer vhost on 443 will proxy only specific locations instead of all traffic, so the Katello WebUI will not be accessible on 443. However, If the user attempts to configure both vhosts on the same port, then only the previously existing vhost will be deployed which allows the WebUI to be accessed on 443. **Going forward when the default is to deploy the newer 443 vhost only, the user retains the choice to opt in to deploying the older style vhost on 443 which includes proxying of all HTTPS traffic rather than specific paths related to RHSM traffic and Pulpcore only**

Future improvements could be cleaning up the implementation inside the Pulpcore module using something like https://github.com/puppetlabs/puppetlabs-apache/pull/2169 , separating the RHSM ProxyPass configuration out of the base 443 vhost resource using the same puppetlabs-apache PR previously mentioned, and bringing the HTTP vhost from Pulpcore to puppet-FPC as well.

**To test: deploy this branch on a foreman-proxy using forklift, register a client on 443 and install some packages.**