### PR TITLE
Fixes #34154 - Refresh on Pulp plugin installation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -352,6 +352,17 @@ class foreman_proxy_content (
     rhsm_path     => $rhsm_path,
   }
 
+  # smart_proxy_pulp dynamically retrieves the Pulp content types and Katello
+  # uses this. This means the features need to be refreshed after a content
+  # type is added. The API also changes so apipie cache needs to be regenerated.
+  # lint:ignore:spaceship_operator_without_tag
+  if $foreman_proxy::register_in_foreman {
+    Pulpcore::Plugin <| |> ~> Foreman_smartproxy[$foreman_proxy::registered_name]
+    Foreman_smartproxy[$foreman_proxy::registered_name] -> Foreman::Rake <| title == 'apipie:cache:index' |>
+  }
+  Pulpcore::Plugin <| |> ~> Foreman::Rake <| title == 'apipie:cache:index' |>
+  # lint:endignore
+
   if $puppet {
     # We can't pull the certs out to the top level, because of how it gets the default
     # parameter values from the main certs class.  Kafo can't handle that case, so

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -25,6 +25,18 @@ describe 'foreman_proxy_content' do
             .with_rhsm_url("https://#{facts[:fqdn]}:443/rhsm")
         end
 
+        context 'with foreman' do
+          let(:pre_condition) { 'include foreman' }
+
+          it { is_expected.to compile.with_all_deps }
+          it do
+            is_expected.to contain_foreman_smartproxy('foo.example.com')
+              .that_subscribes_to('Pulpcore::Plugin[rpm]')
+              .that_comes_before('Foreman::Rake[apipie:cache:index]')
+          end
+          it { is_expected.to contain_foreman__rake('apipie:cache:index').that_subscribes_to('Pulpcore::Plugin[rpm]') }
+        end
+
         context 'with custom service worker timeouts' do
           let(:params) do
             {

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -42,17 +42,15 @@ describe 'foreman_proxy_content' do
           end
         end
 
-        context 'enabling disabled by default content types' do 
-          let(:params) do 
+        context 'enabling disabled by default content types' do
+          let(:params) do
             {
               enable_ostree: true
             }
           end
 
           it { is_expected.to compile.with_all_deps }
-          it do 
-            is_expected.to contain_class('pulpcore::plugin::ostree')
-          end
+          it { is_expected.to contain_class('pulpcore::plugin::ostree') }
         end
 
         context 'with external postgres' do


### PR DESCRIPTION
smart_proxy_pulp dynamically retrieves the Pulp content types and Katello uses this. This means the features need to be refreshed after a content type is added. The API also changes so that cache needs to be regenerated.

This does refreshes on the foreman_smartproxy which could be considered a private API from theforeman/foreman_proxy and collectors would silently be skipped if anything changes. That's why this must be covered by spec tests.

Currently untested on an actual system (which is why this is now a draft) but locally the unit tests passed and having a PR makes it easier to patch a forklift VM.