### PR TITLE
Allow katello/certs 15.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,7 @@
     },
     {
       "name": "katello/certs",
-      "version_requirement": ">= 11.0.0 < 15.0.0"
+      "version_requirement": ">= 11.0.0 < 16.0.0"
     },
     {
       "name": "theforeman/pulpcore",


### PR DESCRIPTION
The breaking change does not affect this module so the old lower bound is kept.