### PR TITLE
Allow theforeman/foreman_proxy 21.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "theforeman/foreman_proxy",
-      "version_requirement": ">= 20.0.0 < 21.0.0"
+      "version_requirement": ">= 20.0.0 < 22.0.0"
     },
     {
       "name": "katello/qpid",


### PR DESCRIPTION
This makes an unrelated breaking change so the previous lower bound is kept.