### PR TITLE
Require at least certs 15

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,7 @@
     },
     {
       "name": "katello/certs",
-      "version_requirement": ">= 11.0.0 < 16.0.0"
+      "version_requirement": ">= 15.0.0 < 16.0.0"
     },
     {
       "name": "theforeman/pulpcore",


### PR DESCRIPTION
certs used to have this, but in version 14 it was absent. Raising the minimum version to 15 is the easiest way to guarantee it is really there.

Fixes: a3ac43579b1f456b11c989a3ef0230718a36a44e