### PR TITLE
Correct the document root in a standalone deployment

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -168,7 +168,7 @@ class foreman_proxy_content (
     }
   }
 
-  if $pulpcore_mirror {
+  unless $shared_with_foreman_vhost {
     $pulpcore_https_vhost_name = "rhsm-pulpcore-https-${rhsm_port}"
 
     if $rhsm_port != $reverse_proxy_port {

--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -16,6 +16,8 @@
 #   Specifies if the virtual host is present or absent.
 # @param priority
 #   Sets the relative load-order for Apache HTTPD VirtualHost configuration files. See Apache::Vhost
+# @param docroot
+#   Define the Apache HTTPD VirtualHost DocumentRoot
 define foreman_proxy_content::reverse_proxy (
   Stdlib::Unixpath $path = '/',
   Stdlib::Httpurl $url = "${foreman_proxy_content::foreman_url}/",
@@ -25,6 +27,7 @@ define foreman_proxy_content::reverse_proxy (
   Hash[String, Variant[String, Integer]] $proxy_pass_params = {'disablereuse' => 'on', 'retry' => '0'},
   Enum['present', 'absent'] $ensure = 'present',
   Optional[Variant[String, Boolean]] $priority = '28',
+  Stdlib::Absolutepath $docroot = '/var/www',
 ) {
   include apache
   include certs::apache

--- a/spec/acceptance/content_standalone_mirror_spec.rb
+++ b/spec/acceptance/content_standalone_mirror_spec.rb
@@ -29,12 +29,11 @@ describe 'pulpcore mirror' do
 
   describe file('/etc/httpd/conf.d/10-pulpcore.conf') do
     it { is_expected.to be_file }
-    it { is_expected.to contain(%r{DocumentRoot "/var/lib/pulp/pulpcore_static}) }
+    it { is_expected.to contain(%r{DocumentRoot "/var/lib/pulp/pulpcore_static"}) }
   end
 
   describe file('/etc/httpd/conf.d/10-rhsm-pulpcore-https-443.conf') do
     it { is_expected.to be_file }
-    # TODO: this is a regression introduced in 76e2a6852d1d2ca33935ccf8a6ab69992c32ec1d
-    it { is_expected.to contain(%{DocumentRoot "/var/www}) }
+    it { is_expected.to contain(%r{DocumentRoot "/var/lib/pulp/pulpcore_static"}) }
   end
 end


### PR DESCRIPTION
The correct document root for Pulp should be set. /var/www may not be correct. The default docroot on Red Hat is /var/www/html so setting it to a higher directory may unintentionally leak files. Pulp actually defines its own to be certain it's empty. In the old reverse proxy setup it didn't really matter since / is proxied which means nothing is served anyway.

Fixes: 76e2a6852d1d2ca33935ccf8a6ab69992c32ec1d