### PR TITLE
Fixes #34819 - disable Puppet by default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,7 +95,7 @@
 class foreman_proxy_content (
   Boolean $pulpcore_mirror = false,
 
-  Boolean $puppet = true,
+  Boolean $puppet = false,
 
   Boolean $reverse_proxy = false,
   Stdlib::Port $reverse_proxy_port = 8443,


### PR DESCRIPTION
We don't enable Puppet in the Katello scenario by default, but having it
true here still pulls in the Agent, which then can't connect anywhere.