### PR TITLE
Fixes #35227 - Load apache::mod::autoindex if needed

### DIFF
--- a/manifests/pub_dir.pp
+++ b/manifests/pub_dir.pp
@@ -12,6 +12,10 @@ class foreman_proxy_content::pub_dir (
 
   include apache::mod::alias
 
+  if '+Indexes' in $pub_dir_options.split(' ') {
+    include apache::mod::autoindex
+  }
+
   pulpcore::apache::fragment { 'pub_dir':
     http_content  => template('foreman_proxy_content/httpd_pub.erb'),
     https_content => template('foreman_proxy_content/httpd_pub.erb'),

--- a/spec/classes/foreman_proxy_content__pub_dir_spec.rb
+++ b/spec/classes/foreman_proxy_content__pub_dir_spec.rb
@@ -8,7 +8,25 @@ describe 'foreman_proxy_content::pub_dir' do
       end
 
       it { should compile.with_all_deps }
+      it { should contain_class('apache::mod::autoindex') }
       it { should contain_package('katello-client-bootstrap') }
+
+      context 'apache without default mods and indexing disabled' do
+        let(:params) do
+          {
+            pub_dir_options: '+FollowSymLinks',
+          }
+        end
+        let(:pre_condition) do
+          <<~PUPPET
+          class { 'apache':
+            default_mods => false,
+          }
+          PUPPET
+        end
+
+        it { should_not contain_class('apache::mod::autoindex') }
+      end
     end
   end
 end


### PR DESCRIPTION
On content proxies we have (by default) /pub as a browsable directory, though it can be disabled by passing a different pub dir option. If it is browsable, mod_autoindex must be loaded. The installer disables loading default mods so it should be loaded explicitly.