### PR TITLE
Allow theforeman/foreman_proxy 23.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "theforeman/foreman_proxy",
-      "version_requirement": ">= 20.0.0 < 23.0.0"
+      "version_requirement": ">= 20.0.0 < 24.0.0"
     },
     {
       "name": "katello/qpid",


### PR DESCRIPTION
The API changes don't affect the module so the lower bound is kept.