### PR TITLE
Refs #35227 - Include mod_dir for indexing

### DIFF
--- a/manifests/pub_dir.pp
+++ b/manifests/pub_dir.pp
@@ -13,6 +13,7 @@ class foreman_proxy_content::pub_dir (
   include apache::mod::alias
 
   if '+Indexes' in $pub_dir_options.split(' ') {
+    include apache::mod::dir
     include apache::mod::autoindex
   }
 


### PR DESCRIPTION
mod_dir is responsible to redirect from /pub to /pub/ which then creates the correct (relative) links.

Having it here does make a cherry pick easier, but long term the question is if this should be in apache::mod::autoindex.