### PR TITLE
Fixes #35681 - Expose hostname and cname parameters

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "theforeman/pulpcore",
-      "version_requirement": ">= 7.0.1 < 8.0.0"
+      "version_requirement": ">= 7.1.0 < 8.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Alternative to https://github.com/theforeman/puppet-foreman_proxy_content/pull/432. Passing the aliases to Apache is especially important when there are multiple vhosts or when using [mod_md](https://httpd.apache.org/docs/2.4/mod/mod_md.html). While today we don't do either, having the option is good. It can also help with debugging since sosreport does collect the vhosts, but not the certificates. If ServerAliases matches what's on the certificate, that can give a hint.