### PR TITLE
Fixes #36854 - Use HTTP/2 when proxying to Foreman

### DIFF
--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -15,7 +15,7 @@
 # @param priority
 #   Sets the relative load-order for Apache HTTPD VirtualHost configuration files. See Apache::Vhost
 define foreman_proxy_content::reverse_proxy (
-  Hash[Stdlib::Unixpath, Stdlib::Httpurl] $path_url_map = { '/' => "${foreman_proxy_content::foreman_url}/" },
+  Hash[Stdlib::Unixpath, String[1]] $path_url_map = { '/' => "${foreman_proxy_content::foreman_url}/" },
   Stdlib::Port $port = $foreman_proxy_content::reverse_proxy_port,
   Variant[Array[String], String, Undef] $ssl_protocol = undef,
   Hash[String, Any] $vhost_params = {},
@@ -31,7 +31,7 @@ define foreman_proxy_content::reverse_proxy (
 
   $vhost_name = $title
 
-  $proxy_pass = $path_url_map.map |Stdlib::Unixpath $path, Stdlib::Httpurl $url| {
+  $proxy_pass = $path_url_map.map |$path, $url| {
     {
       'path'         => $path,
       'url'          => $url,

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 2.0.0 < 12.0.0"
+      "version_requirement": ">= 10.1.1 < 12.0.0"
     },
     {
       "name": "theforeman/foreman_proxy",

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -201,14 +201,14 @@ describe 'foreman_proxy_content' do
         end
         it do
           is_expected.to contain_foreman_proxy_content__reverse_proxy('rhsm-pulpcore-https-8443')
-            .with(path_url_map: {'/' => 'https://foo.example.com/'})
+            .with(path_url_map: {'/' => 'h2://foo.example.com/'})
             .with(port: 8443)
             .with(priority: '10')
             .that_comes_before('Class[pulpcore::apache]')
         end
         it do
           is_expected.to contain_foreman_proxy_content__reverse_proxy('rhsm-pulpcore-https-443')
-            .with(path_url_map: {'/rhsm' => 'https://foo.example.com/rhsm', '/redhat_access' => 'https://foo.example.com/redhat_access'})
+            .with(path_url_map: {'/rhsm' => 'h2://foo.example.com/rhsm', '/redhat_access' => 'h2://foo.example.com/redhat_access'})
             .with(port: 443)
             .with(priority: '10')
             .that_comes_before('Class[pulpcore::apache]')


### PR DESCRIPTION
This aims to use mod_proxy_http2, which utilizes HTTP/2 to a backend server. It depends on a feature released in puppetlabs-apache 10.1.1.

Overall testing shows the connection is much more stable and reliable than with HTTP/1.1, especially in higher concurrency. It is recommended to keep this on, but there is an option to disable it if for some reason it doesn't work.
