### PR TITLE
Fixes #36709 - Set ANSIBLE_PERMISSION_CLASSES to empty list

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -301,6 +301,7 @@ class foreman_proxy_content (
   }
   if $enable_ansible {
     class { 'pulpcore::plugin::ansible':
+      permission_classes => [],
     }
   }
   if $enable_python {

--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "theforeman/pulpcore",
-      "version_requirement": ">= 8.4.0 < 9.0.0"
+      "version_requirement": ">= 8.5.0 < 9.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
This allows syncing collection repos on capsule without RBAC access to Galaxy endpoints.

Depends on https://github.com/theforeman/puppet-pulpcore/pull/306 for theforeman/pulpcore 8.5.0.