### PR TITLE
Mark compatible with theforeman/pulpcore 9.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "theforeman/pulpcore",
-      "version_requirement": ">= 8.5.0 < 9.0.0"
+      "version_requirement": ">= 8.5.0 < 10.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
This new major version dropped Pulpcore < 3.39, but didn't change the API so both versions are compatible.