### PR TITLE
Require pulpcore 10.x for pulpcore::analytics parameter

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "theforeman/pulpcore",
-      "version_requirement": ">= 8.5.0 < 11.0.0"
+      "version_requirement": ">= 10.0.0 < 11.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Fixes: b9d0e0d45933 ("Refs #37062 - Use pulpcore::analytics instead of pulpcore::telemetry")