### PR TITLE
Allow puppetlabs/apache 12.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 10.1.1 < 12.0.0"
+      "version_requirement": ">= 10.1.1 < 13.0.0"
     },
     {
       "name": "theforeman/foreman_proxy",


### PR DESCRIPTION
We need 12.0.3+ for Puppet 8 support due to https://github.com/puppetlabs/puppetlabs-apache/pull/2525