### PR TITLE
Fixes #37325 - make postgres the container gateway default DB

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -280,6 +280,16 @@ class foreman_proxy_content (
         pulp_endpoint => "https://${servername}",
       }
     }
+    include postgresql::client
+    include postgresql::server
+    include postgresql::server::contrib
+    postgresql::server::db { $foreman_proxy::plugin::postgresql_database:
+      user     => $foreman_proxy::plugin::postgresql_user,
+      password => postgresql::postgresql_password($foreman_proxy::plugin::postgresql_user, $foreman_proxy::plugin::postgresql_db_password),
+      encoding => 'utf8',
+      locale   => 'en_US.utf8',
+      require  => Package['glibc-langpack-en'],
+    }
   }
   if $enable_file {
     class { 'pulpcore::plugin::file':


### PR DESCRIPTION
Draft PR to instantiate the postgres database for the container gateway. The main PR is here: https://github.com/theforeman/puppet-foreman_proxy/pull/835

I'm not totally sure if foreman_proxy_content is the proper spot to create the DB, but it seemed better than doing it in foreman_proxy and adding a postgres library requirement there.

I'm looking for general feedback on what things I might be missing between the two PRs since I don't work on Puppet modules often.