### PR TITLE
enforce xz compression for consumer rpm

### DIFF
--- a/lib/puppet/provider/bootstrap_rpm/bootstrap_rpm.rb
+++ b/lib/puppet/provider/bootstrap_rpm/bootstrap_rpm.rb
@@ -95,6 +95,7 @@ Puppet::Type.type(:bootstrap_rpm).provide(:bootstrap_rpm) do
       '-ba',
       File.join(spec_dir, "#{resource[:name]}.spec"),
       '--define', "_topdir #{base_dir}",
+      '--define', '_binary_payload w2.xzdio',
       '--define', "name #{resource[:name]}",
       '--define', "release #{release}"
     )

--- a/spec/acceptance/bootstrap_rpm_spec.rb
+++ b/spec/acceptance/bootstrap_rpm_spec.rb
@@ -60,6 +60,8 @@ describe 'bootstrap_rpm', :order => :defined do
 
     describe command('rpm -qp /var/www/html/pub/katello-ca-consumer-latest.noarch.rpm --requires') do
       its(:stdout) { should match(/^subscription-manager/) }
+      its(:stdout) { should match(/PayloadIsXz/) }
+      its(:stdout) { should_not match(/PayloadIsZstd/) }
     end
 
     describe command('rpm -qp /var/www/html/pub/katello-ca-consumer-latest.noarch.rpm --list') do


### PR DESCRIPTION
EL9+ defaults to zstd, but EL7 can't consume that
