### PR TITLE
Set Apache parameters in ci to reflect the real deployment

### DIFF
--- a/spec/acceptance/hieradata/common.yaml
+++ b/spec/acceptance/hieradata/common.yaml
@@ -1,5 +1,13 @@
 ---
 apache::default_mods: false
+# This is normally set in the installer, but the bootstrap_rpm test needs it
+#apache::default_vhost: false
+apache::mpm_module: 'event'
+apache::protocols:
+  - 'h2'
+  - 'h2c'
+  - 'http/1.1'
+
 foreman_proxy::manage_puppet_group: false
 foreman_proxy::puppet: false
 foreman_proxy::puppetca: false


### PR DESCRIPTION
The installer has these values set and this makes the test more representative of the real world.