### PR TITLE
Mark compatible with katello/certs 18.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "katello/certs",
-      "version_requirement": ">= 15.0.0 < 18.0.0"
+      "version_requirement": ">= 15.0.0 < 19.0.0"
     },
     {
       "name": "theforeman/pulpcore",


### PR DESCRIPTION
Breaking changes removed some options that aren't used in this module so it's only raising the upper version bound.