### PR TITLE
Mark compatible with theforeman/foreman_proxy 26.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "theforeman/foreman_proxy",
-      "version_requirement": ">= 20.0.0 < 26.0.0"
+      "version_requirement": ">= 20.0.0 < 27.0.0"
     },
     {
       "name": "katello/certs",


### PR DESCRIPTION
That release changed the container_gateway plugin. That is used here, but we don't expose the parameters. It introduces a PostgreSQL database.  For proper external database support, this module should also start to expose it.