### PR TITLE
Fixes #37701: Default 8443 reverse proxy to off

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,6 +11,7 @@ fixtures:
       repo: "https://github.com/puppetlabs/puppetlabs-cron_core"
       puppet_version: ">= 6.0.0"
     datacat:       "https://github.com/richardc/puppet-datacat"
+    dns:           "https://github.com/theforeman/puppet-dns.git"
     candlepin:     "https://github.com/theforeman/puppet-candlepin.git"
     foreman_proxy: "https://github.com/theforeman/puppet-foreman_proxy.git"
     foreman:       "https://github.com/theforeman/puppet-foreman"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,7 +122,7 @@ class foreman_proxy_content (
 
   $foreman_url = $foreman_proxy::foreman_base_url
   $foreman_host = foreman_proxy_content::host_from_url($foreman_url)
-  $reverse_proxy_real = $pulpcore_mirror or $reverse_proxy
+  $reverse_proxy_real = $pulpcore_mirror and $reverse_proxy
   $proxy_foreman_url = $foreman_url.regsubst('https://', "${reverse_proxy_backend_protocol}://")
 
   # TODO: make it configurable

--- a/spec/acceptance/content_standalone_mirror_spec.rb
+++ b/spec/acceptance/content_standalone_mirror_spec.rb
@@ -1,49 +1,107 @@
 require 'spec_helper_acceptance'
 
 describe 'pulpcore mirror' do
-  it_behaves_like 'an idempotent resource' do
-    let(:manifest) do
-      <<~PUPPET
-      include certs::foreman_proxy
+  context 'with default params' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PUPPET
+        include certs::foreman_proxy
 
-      class { 'foreman_proxy':
-        register_in_foreman => false,
-        ssl_ca              => $certs::foreman_proxy::proxy_ca_cert,
-        ssl_cert            => $certs::foreman_proxy::proxy_cert,
-        ssl_key             => $certs::foreman_proxy::proxy_key,
-      }
+        class { 'foreman_proxy':
+          register_in_foreman => false,
+          ssl_ca              => $certs::foreman_proxy::proxy_ca_cert,
+          ssl_cert            => $certs::foreman_proxy::proxy_cert,
+          ssl_key             => $certs::foreman_proxy::proxy_key,
+        }
 
-      class { 'foreman_proxy_content':
-        pulpcore_mirror => true,
-        # No Ansible repo is set up in our CI
-        enable_ansible  => false,
-      }
-      PUPPET
+        class { 'foreman_proxy_content':
+          pulpcore_mirror => true,
+          # No Ansible repo is set up in our CI
+          enable_ansible  => false,
+        }
+        PUPPET
+      end
+    end
+
+    describe service('httpd') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+
+    describe file('/etc/httpd/conf.d/10-pulpcore.conf') do
+      it { is_expected.to be_file }
+      it { is_expected.to contain(%r{DocumentRoot "/var/lib/pulp/pulpcore_static}) }
+    end
+
+    describe file('/etc/httpd/conf.d/10-rhsm-pulpcore-https-443.conf') do
+      it { is_expected.to be_file }
+      # TODO: this is a regression introduced in 76e2a6852d1d2ca33935ccf8a6ab69992c32ec1d
+      it { is_expected.to contain(%{DocumentRoot "/var/www}) }
+    end
+
+    describe service('qdrouterd') do
+      it { is_expected.not_to be_running }
+      it { is_expected.not_to be_enabled }
+    end
+
+    describe port('5647') do
+      it { is_expected.not_to be_listening }
+    end
+
+    describe port('443') do
+      it { is_expected.to be_listening }
+    end
+
+    describe port('8443') do
+      it { is_expected.not_to be_listening }
     end
   end
 
-  describe service('httpd') do
-    it { is_expected.to be_running }
-    it { is_expected.to be_enabled }
-  end
+  context 'with reverse_proxy true' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PUPPET
+        include certs::foreman_proxy
 
-  describe file('/etc/httpd/conf.d/10-pulpcore.conf') do
-    it { is_expected.to be_file }
-    it { is_expected.to contain(%r{DocumentRoot "/var/lib/pulp/pulpcore_static}) }
-  end
+        class { 'foreman_proxy':
+          register_in_foreman => false,
+          ssl_ca              => $certs::foreman_proxy::proxy_ca_cert,
+          ssl_cert            => $certs::foreman_proxy::proxy_cert,
+          ssl_key             => $certs::foreman_proxy::proxy_key,
+        }
 
-  describe file('/etc/httpd/conf.d/10-rhsm-pulpcore-https-443.conf') do
-    it { is_expected.to be_file }
-    # TODO: this is a regression introduced in 76e2a6852d1d2ca33935ccf8a6ab69992c32ec1d
-    it { is_expected.to contain(%{DocumentRoot "/var/www}) }
-  end
+        class { 'foreman_proxy_content':
+          pulpcore_mirror => true,
+          reverse_proxy   => true,
+          # No Ansible repo is set up in our CI
+          enable_ansible  => false,
+        }
+        PUPPET
+      end
+    end
 
-  describe service('qdrouterd') do
-    it { is_expected.not_to be_running }
-    it { is_expected.not_to be_enabled }
-  end
+    describe service('httpd') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
 
-  describe port('5647') do
-    it { is_expected.not_to be_listening }
+    describe file('/etc/httpd/conf.d/10-pulpcore.conf') do
+      it { is_expected.to be_file }
+      it { is_expected.to contain(%r{DocumentRoot "/var/lib/pulp/pulpcore_static}) }
+    end
+
+    describe file('/etc/httpd/conf.d/10-rhsm-pulpcore-https-443.conf') do
+      it { is_expected.to be_file }
+      # TODO: this is a regression introduced in 76e2a6852d1d2ca33935ccf8a6ab69992c32ec1d
+      it { is_expected.to contain(%{DocumentRoot "/var/www}) }
+    end
+
+    describe port('443') do
+      it { is_expected.to be_listening }
+    end
+
+    describe port('8443') do
+      it { is_expected.to be_listening }
+    end
   end
 end

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -199,11 +199,7 @@ describe 'foreman_proxy_content' do
             .with_rhsm_url("https://#{facts[:fqdn]}:443/rhsm")
         end
         it do
-          is_expected.to contain_foreman_proxy_content__reverse_proxy('rhsm-pulpcore-https-8443')
-            .with(path_url_map: {'/' => 'h2://foo.example.com/'})
-            .with(port: 8443)
-            .with(priority: '10')
-            .that_comes_before('Class[pulpcore::apache]')
+          is_expected.not_to contain_foreman_proxy_content__reverse_proxy('rhsm-pulpcore-https-8443')
         end
         it do
           is_expected.to contain_foreman_proxy_content__reverse_proxy('rhsm-pulpcore-https-443')
@@ -263,6 +259,23 @@ describe 'foreman_proxy_content' do
           end
 
           it { is_expected.not_to compile.with_all_deps }
+        end
+      end
+
+      context 'with deprecated_reverse_proxy_port' do
+        let(:params) do
+          {
+            pulpcore_mirror: true,
+            reverse_proxy: true,
+          }
+        end
+
+        it do
+          is_expected.to contain_foreman_proxy_content__reverse_proxy('rhsm-pulpcore-https-8443')
+            .with(path_url_map: {'/' => 'h2://foo.example.com/'})
+            .with(port: 8443)
+            .with(priority: '10')
+            .that_comes_before('Class[pulpcore::apache]')
         end
       end
     end


### PR DESCRIPTION
This prepares us to remove this in the next release by getting users used to this being off by default. For upgraded systems, this will disable port 8443 and any user who actually still needs it will have to explicitly enable it.