### PR TITLE
Fixes #37707 - Purge container_gateway feature without docker

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -280,6 +280,10 @@ class foreman_proxy_content (
         pulp_endpoint => "https://${servername}",
       }
     }
+  } else {
+    class { 'foreman_proxy::plugin::container_gateway':
+      version => 'absent',
+    }
   }
   if $enable_file {
     class { 'pulpcore::plugin::file':

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "theforeman/foreman_proxy",
-      "version_requirement": ">= 20.0.0 < 27.0.0"
+      "version_requirement": ">= 26.1.0 < 27.0.0"
     },
     {
       "name": "katello/certs",

--- a/spec/acceptance/content_standalone_mirror_spec.rb
+++ b/spec/acceptance/content_standalone_mirror_spec.rb
@@ -104,4 +104,36 @@ describe 'pulpcore mirror' do
       it { is_expected.to be_listening }
     end
   end
+
+  describe package('rubygem-smart_proxy_container_gateway') do
+    it { is_expected.to be_installed }
+  end
+
+  context 'with docker disabled' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PUPPET
+        include certs::foreman_proxy
+
+        class { 'foreman_proxy':
+          register_in_foreman => false,
+          ssl_ca              => $certs::foreman_proxy::proxy_ca_cert,
+          ssl_cert            => $certs::foreman_proxy::proxy_cert,
+          ssl_key             => $certs::foreman_proxy::proxy_key,
+        }
+
+        class { 'foreman_proxy_content':
+          pulpcore_mirror => true,
+          enable_docker   => false,
+          # No Ansible repo is set up in our CI
+          enable_ansible  => false,
+        }
+        PUPPET
+      end
+    end
+
+    describe package('rubygem-smart_proxy_container_gateway') do
+      it { is_expected.not_to be_installed }
+    end
+  end
 end

--- a/spec/acceptance/hieradata/common.yaml
+++ b/spec/acceptance/hieradata/common.yaml
@@ -4,3 +4,6 @@ foreman_proxy::manage_puppet_group: false
 foreman_proxy::puppet: false
 foreman_proxy::puppetca: false
 foreman_proxy::ssl_port: 9090
+
+# Fix idempotency in pulpcore
+pulpcore::database::always_run_migrations: false


### PR DESCRIPTION
If smart_proxy_container_gateway was already installed on a host and then enable-docker => false is used, it leaves it enabled but without Apache proxy config. On Foreman it'll also be reported as a feature.  This is inconsistent.

The new code ensures the feature is actually purged.

It's a draft because it relies on https://github.com/theforeman/puppet-foreman_proxy/pull/843 to work properly. Otherwise it'll start to install a database and deploy the config file.