### PR TITLE
Fixes #37620 - Use the correct docroot in the reverse proxy setup

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -146,22 +146,6 @@ class foreman_proxy_content (
     }
   }
 
-  if $pulpcore_mirror {
-    $pulpcore_https_vhost_name = "rhsm-pulpcore-https-${rhsm_port}"
-
-    if $rhsm_port != $reverse_proxy_port {
-      foreman_proxy_content::reverse_proxy { $pulpcore_https_vhost_name:
-        path_url_map => {
-          $rhsm_path     => "${proxy_foreman_url}${rhsm_path}",
-          $insights_path => "${proxy_foreman_url}${insights_path}",
-        },
-        port         => $rhsm_port,
-        priority     => '10',
-        before       => Class['pulpcore::apache'],
-      }
-    }
-  }
-
   include foreman_proxy_content::pub_dir
 
   if $pulpcore_mirror {
@@ -199,7 +183,7 @@ class foreman_proxy_content (
     $serveraliases = $certs::apache::cname
     $priority = '10'
     $apache_http_vhost = undef
-    $apache_https_vhost = $pulpcore_https_vhost_name
+    $apache_https_vhost = "rhsm-pulpcore-https-${rhsm_port}"
     $apache_https_cert = undef
     $apache_https_key = undef
     $apache_https_ca = undef
@@ -266,6 +250,19 @@ class foreman_proxy_content (
       cert         => $certs::foreman::client_cert,
       key          => $certs::foreman::client_key,
       require      => Class['certs::foreman'],
+    }
+  } elsif $pulpcore_mirror {
+    if $rhsm_port != $reverse_proxy_port {
+      foreman_proxy_content::reverse_proxy { $apache_https_vhost:
+        docroot      => $pulpcore::apache_docroot,
+        path_url_map => {
+          $rhsm_path     => "${proxy_foreman_url}${rhsm_path}",
+          $insights_path => "${proxy_foreman_url}${insights_path}",
+        },
+        port         => $rhsm_port,
+        priority     => '10',
+        before       => Class['pulpcore::apache'],
+      }
     }
   }
 

--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -1,5 +1,7 @@
 # Adds http reverse-proxy to parent conf
 #
+# @param docroot
+#   The document root for the reverse proxy to use
 # @param path_url_map
 #   The paths and corresponding URLs where to mount the reverse proxy
 # @param port
@@ -15,6 +17,7 @@
 # @param priority
 #   Sets the relative load-order for Apache HTTPD VirtualHost configuration files. See Apache::Vhost
 define foreman_proxy_content::reverse_proxy (
+  Stdlib::Absolutepath $docroot = '/var/www/html',
   Hash[Stdlib::Unixpath, String[1]] $path_url_map = { '/' => "${foreman_proxy_content::foreman_url}/" },
   Stdlib::Port $port = $foreman_proxy_content::reverse_proxy_port,
   Variant[Array[String], String, Undef] $ssl_protocol = undef,
@@ -45,8 +48,9 @@ define foreman_proxy_content::reverse_proxy (
     servername             => $certs::apache::hostname,
     serveraliases          => $certs::apache::cname,
     port                   => $port,
-    docroot                => '/var/www/',
+    docroot                => $docroot,
     priority               => $priority,
+    options                => ['FollowSymLinks'],
     ssl_options            => ['+StdEnvVars', '+ExportCertData', '+FakeBasicAuth'],
     ssl                    => true,
     ssl_proxyengine        => true,

--- a/spec/acceptance/content_standalone_mirror_spec.rb
+++ b/spec/acceptance/content_standalone_mirror_spec.rb
@@ -35,8 +35,7 @@ describe 'pulpcore mirror' do
 
     describe file('/etc/httpd/conf.d/10-rhsm-pulpcore-https-443.conf') do
       it { is_expected.to be_file }
-      # TODO: this is a regression introduced in 76e2a6852d1d2ca33935ccf8a6ab69992c32ec1d
-      it { is_expected.to contain(%{DocumentRoot "/var/www}) }
+      it { is_expected.to contain('DocumentRoot "/var/lib/pulp/pulpcore_static"') }
     end
 
     describe port('443') do
@@ -83,8 +82,7 @@ describe 'pulpcore mirror' do
 
     describe file('/etc/httpd/conf.d/10-rhsm-pulpcore-https-443.conf') do
       it { is_expected.to be_file }
-      # TODO: this is a regression introduced in 76e2a6852d1d2ca33935ccf8a6ab69992c32ec1d
-      it { is_expected.to contain(%{DocumentRoot "/var/www}) }
+      it { is_expected.to contain('DocumentRoot "/var/lib/pulp/pulpcore_static"') }
     end
 
     describe port('443') do


### PR DESCRIPTION
This is a code dump of what I was working on.