### PR TITLE
Fix idempotency with pulpcore's migrations

### DIFF
--- a/spec/acceptance/hieradata/common.yaml
+++ b/spec/acceptance/hieradata/common.yaml
@@ -4,3 +4,6 @@ foreman_proxy::manage_puppet_group: false
 foreman_proxy::puppet: false
 foreman_proxy::puppetca: false
 foreman_proxy::ssl_port: 9090
+
+# Fix idempotency in pulpcore
+pulpcore::database::always_run_migrations: false


### PR DESCRIPTION
puppet-pulpcore can no longer guarantee idempotency and reliably migrate the database[1]. An option[2] was introduced to pretend it's idempotent, which in upgrades may break but is good enough for CI.

[1]: https://github.com/theforeman/puppet-pulpcore/commit/f8d0dc629799a1fadabd3967de62173d0e91a048
[2]: https://github.com/theforeman/puppet-pulpcore/commit/0004d05da6424a8bcba92e73c106249b8ca2f499