### PR TITLE
Remove qpid leftovers in acceptance tests

### DIFF
--- a/spec/acceptance/content_standalone_mirror_spec.rb
+++ b/spec/acceptance/content_standalone_mirror_spec.rb
@@ -39,15 +39,6 @@ describe 'pulpcore mirror' do
       it { is_expected.to contain(%{DocumentRoot "/var/www}) }
     end
 
-    describe service('qdrouterd') do
-      it { is_expected.not_to be_running }
-      it { is_expected.not_to be_enabled }
-    end
-
-    describe port('5647') do
-      it { is_expected.not_to be_listening }
-    end
-
     describe port('443') do
       it { is_expected.to be_listening }
     end

--- a/spec/acceptance/content_with_foreman_spec.rb
+++ b/spec/acceptance/content_with_foreman_spec.rb
@@ -67,13 +67,4 @@ describe 'pulpcore non-mirror' do
     its(:stdout) { is_expected.to match(/admin/) }
     its(:stderr) { is_expected.not_to match(/Error/) }
   end
-
-  describe service('qdrouterd') do
-    it { is_expected.not_to be_running }
-    it { is_expected.not_to be_enabled }
-  end
-
-  describe port('5647') do
-    it { is_expected.not_to be_listening }
-  end
 end


### PR DESCRIPTION
Fixes: 1c787b10b0d2f3bb4dbe1a7b7095feab03786a07 ("Remove qpid class")