### PR TITLE
Drop redundant update-ca-trust enable step

### DIFF
--- a/lib/puppet/provider/rhsm_reconfigure_script/rhsm_reconfigure_script.rb
+++ b/lib/puppet/provider/rhsm_reconfigure_script/rhsm_reconfigure_script.rb
@@ -125,9 +125,8 @@ Puppet::Type.type(:rhsm_reconfigure_script).provide(:rhsm_reconfigure_script) do
 
       # also add the katello ca cert to the system wide ca cert store
       if [ -d $CA_TRUST_ANCHORS ]; then
-        update-ca-trust enable
         cp $CERT_DIR/$KATELLO_SERVER_CA_CERT $CA_TRUST_ANCHORS
-        update-ca-trust
+        update-ca-trust extract
       fi
 
       # restart yggdrasild if it is installed and running


### PR DESCRIPTION
On EL 7 & 8 the argument is ignored, so it effectively ran twice. On EL 9 since ca-certificates-0:2024.2.69_v8.0.303-91.3.el9 it does check the argument and changes behavior. The on 91.3 it hard fails on enable while 91.4 yields a deprecation warning. It still effectively runs twice.

This drops the redundant step because it only needs to extract after the new CA has been added.

See https://github.com/voxpupuli/puppet-trusted_ca/pull/69 for a lot more context on this.