### PR TITLE
Use registration_url to define the container gateway Pulp endpoint

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -256,7 +256,7 @@ class foreman_proxy_content (
       }
 
       class { 'foreman_proxy::plugin::container_gateway':
-        pulp_endpoint => "https://${servername}",
+        pulp_endpoint => "https://${client_facing_servername}",
       }
     }
   } else {

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -244,6 +244,11 @@ describe 'foreman_proxy_content' do
             is_expected.to contain_class('foreman_proxy::plugin::pulp')
               .with_pulpcore_content_url("https://loadbalancer.example.com/pulp/content")
           end
+
+          it do
+            is_expected.to contain_class('foreman_proxy::plugin::container_gateway')
+              .with_pulp_endpoint("https://loadbalancer.example.com")
+          end
         end
 
         describe 'should throw an error if cname and registration_url do not match' do


### PR DESCRIPTION
This is needed when using a load-balanced setup or else the container gateway authorization check will redirect to the hostname which may be inaccessible to the client.