### PR TITLE
Add enablement parameter for bootstrap RPMs

### DIFF
--- a/manifests/bootstrap_rpm.pp
+++ b/manifests/bootstrap_rpm.pp
@@ -2,6 +2,7 @@
 # This file is placed in $rpm_serve_dir.
 # @api private
 class foreman_proxy_content::bootstrap_rpm (
+  Enum['present', 'absent'] $ensure = 'present',
   Stdlib::Fqdn $rhsm_hostname = $facts['networking']['fqdn'],
   Stdlib::Port $rhsm_port = 443,
   Pattern[/\A(\/[a-zA-Z0-9]+)+(\/)?\z/] $rhsm_path = '/rhsm',
@@ -48,7 +49,7 @@ class foreman_proxy_content::bootstrap_rpm (
     require => File[$katello_server_ca_cert],
   } ->
   rhsm_reconfigure_script { "${rpm_serve_dir}/${katello_rhsm_setup_script}":
-    ensure          => present,
+    ensure          => $ensure,
     default_ca_cert => $ca_cert,
     server_ca_cert  => $katello_server_ca_cert,
     default_ca_name => $default_ca_name,
@@ -62,7 +63,7 @@ class foreman_proxy_content::bootstrap_rpm (
   }
 
   bootstrap_rpm { $bootstrap_rpm_name:
-    ensure  => present,
+    ensure  => $ensure,
     script  => "${rpm_serve_dir}/${katello_rhsm_setup_script}",
     dest    => $rpm_serve_dir,
     symlink => "${rpm_serve_dir}/${candlepin_cert_rpm_alias_filename}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,8 @@
 #
 # $pulpcore_import_workers_percent::           What percentage of available-workers will pulpcore use for import tasks at a time
 #
+# $ensure_bootstrap_rpm::                      Enable the deployment of the bootstrap RPM
+#
 class foreman_proxy_content (
   Boolean $pulpcore_mirror = false,
 
@@ -110,6 +112,7 @@ class foreman_proxy_content (
   Boolean $pulpcore_analytics = false,
   Boolean $pulpcore_hide_guarded_distributions = true,
   Optional[Integer[1,100]] $pulpcore_import_workers_percent = undef,
+  Enum['present', 'absent'] $ensure_bootstrap_rpm = 'present',
 ) inherits foreman_proxy_content::params {
   include certs
   include foreman_proxy
@@ -130,7 +133,9 @@ class foreman_proxy_content (
   include certs::foreman_proxy
   Class['certs::foreman_proxy'] ~> Service['foreman-proxy']
 
-  include foreman_proxy_content::pub_dir
+  class { 'foreman_proxy_content::pub_dir':
+    ensure_bootstrap => $ensure_bootstrap_rpm,
+  }
 
   if $pulpcore_mirror {
     $base_allowed_import_paths    = ['/var/lib/pulp/sync_imports']
@@ -307,6 +312,7 @@ class foreman_proxy_content (
   }
 
   class { 'foreman_proxy_content::bootstrap_rpm':
+    ensure        => $ensure_bootstrap_rpm,
     rhsm_hostname => $client_facing_servername,
     rhsm_port     => $rhsm_port,
     rhsm_path     => $rhsm_path,

--- a/manifests/pub_dir.pp
+++ b/manifests/pub_dir.pp
@@ -5,10 +5,14 @@
 #
 # @param pub_dir_options
 #   The Directory options as Apache applies them
+#
+# @param ensure_bootstrap
+#   Enable installing the katello-client-bootstrap RPM
 class foreman_proxy_content::pub_dir (
   String $pub_dir_options = '+FollowSymLinks +Indexes',
+  Enum['present', 'absent'] $ensure_bootstrap = 'present',
 ) {
-  stdlib::ensure_packages('katello-client-bootstrap')
+  stdlib::ensure_packages('katello-client-bootstrap', { 'ensure' => $ensure_bootstrap })
 
   include apache::mod::alias
 

--- a/spec/acceptance/bootstrap_rpm_spec.rb
+++ b/spec/acceptance/bootstrap_rpm_spec.rb
@@ -272,4 +272,36 @@ describe 'bootstrap_rpm', :order => :defined do
       it { should be_linked_to "/var/www/html/pub/katello-ca-consumer-#{host_inventory['fqdn']}-1.0-2.noarch.rpm" }
     end
   end
+
+  context 'removes RPM when ensure is false' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+        class { 'foreman_proxy_content::bootstrap_rpm':
+          ensure => 'absent',
+        }
+        PUPPET
+      end
+    end
+
+    describe file("/var/www/html/pub/katello-ca-consumer-#{host_inventory['fqdn']}-1.0-1.src.rpm") do
+      it { should_not exist }
+    end
+
+    describe file("/var/www/html/pub/katello-ca-consumer-#{host_inventory['fqdn']}-1.0-4.src.rpm") do
+      it { should_not exist }
+    end
+
+    describe file("/var/www/html/pub/katello-ca-consumer-#{host_inventory['fqdn']}-1.0-10.src.rpm") do
+      it { should_not exist }
+    end
+
+    describe file('/var/www/html/pub/katello-ca-consumer-latest.noarch.rpm') do
+      it { should_not exist }
+    end
+
+    describe file('/var/www/html/pub/katello-rhsm-consumer') do
+      it { should_not exist }
+    end
+  end
 end

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -261,6 +261,24 @@ describe 'foreman_proxy_content' do
           it { is_expected.not_to compile.with_all_deps }
         end
       end
+
+      context 'with boostrap_rpm false' do
+        let(:params) do
+          {
+            ensure_bootstrap_rpm: 'absent'
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it do
+          is_expected.to contain_package('katello-client-bootstrap')
+            .with_ensure('absent')
+        end
+        it do
+          is_expected.to contain_class('foreman_proxy_content::bootstrap_rpm')
+            .with_ensure('absent')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This will allow us to disable the bootstrap RPM and the consumer RPM when we are ready. The only odd situation is if someone were to re-enable it the RPM counter would start back at 1 which clients with the RPM already would not upgrade to without being forced.