### PR TITLE
Use the Apache CA cert as SSL proxy cert

### DIFF
--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -54,7 +54,7 @@ define foreman_proxy_content::reverse_proxy (
     ssl_options            => ['+StdEnvVars', '+ExportCertData', '+FakeBasicAuth'],
     ssl                    => true,
     ssl_proxyengine        => true,
-    ssl_proxy_ca_cert      => $certs::ca_cert,
+    ssl_proxy_ca_cert      => $certs::apache::apache_ca_cert,
     ssl_proxy_machine_cert => $certs::foreman_proxy::foreman_proxy_ssl_client_bundle,
     ssl_cert               => $certs::apache::apache_cert,
     ssl_key                => $certs::apache::apache_key,


### PR DESCRIPTION
This replaces the `certs::ca_cert` variable with `certs::apache::apache_ca_cert` because the former has been removed in git. It's safe to assume Foreman is using the same CA certificate as the vhost itself is using.