### PR TITLE
Add proxy pass entry for lightspeed API

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -126,6 +126,7 @@ class foreman_proxy_content (
   $rhsm_port = 443
 
   $insights_path = '/redhat_access'
+  $lightspeed_path = '/api/lightspeed'
 
   include certs::foreman_proxy
   Class['certs::foreman_proxy'] ~> Service['foreman-proxy']
@@ -239,8 +240,9 @@ class foreman_proxy_content (
     foreman_proxy_content::reverse_proxy { $apache_https_vhost:
       docroot      => $pulpcore::apache_docroot,
       path_url_map => {
-        $rhsm_path     => "${proxy_foreman_url}${rhsm_path}",
-        $insights_path => "${proxy_foreman_url}${insights_path}",
+        $rhsm_path       => "${proxy_foreman_url}${rhsm_path}",
+        $insights_path   => "${proxy_foreman_url}${insights_path}",
+        $lightspeed_path => "${proxy_foreman_url}${lightspeed_path}",
       },
       port         => $rhsm_port,
       priority     => '10',

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -203,7 +203,11 @@ describe 'foreman_proxy_content' do
         end
         it do
           is_expected.to contain_foreman_proxy_content__reverse_proxy('rhsm-pulpcore-https-443')
-            .with(path_url_map: {'/rhsm' => 'h2://foo.example.com/rhsm', '/redhat_access' => 'h2://foo.example.com/redhat_access'})
+            .with(path_url_map: {
+              '/rhsm' => 'h2://foo.example.com/rhsm',
+              '/redhat_access' => 'h2://foo.example.com/redhat_access',
+              '/api/lightspeed' => 'h2://foo.example.com/api/lightspeed',
+            })
             .with(port: 443)
             .with(priority: '10')
             .that_comes_before('Class[pulpcore::apache]')


### PR DESCRIPTION
The change [in foreman_rh_cloud](https://github.com/theforeman/foreman_rh_cloud/pull/972) introduces proxying the lightspeed endpoint to the Red Hat cloud. This enables hosts connected through a content proxy to also send their traffic at this new API.