### PR TITLE
Require a version of theforeman/foreman_proxy w/ client_endpoint

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "theforeman/foreman_proxy",
-      "version_requirement": ">= 26.1.0 < 29.0.0"
+      "version_requirement": ">= 28.1.0 < 29.0.0"
     },
     {
       "name": "katello/certs",


### PR DESCRIPTION
Requires https://github.com/theforeman/puppet-foreman_proxy/pull/864

Fixes: 9d8dc8fddcc1d41c290a75687dc762bfb1692d87 ("Set client_endpoint on container_gateway plugin")