### PR TITLE
Add Apache proxy for flatpak index

### DIFF
--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -8,6 +8,8 @@
 # @param registry_v2_path
 #   The path beneath the location prefix to forward. This is also appended to
 #   the content base url.
+# @param flatpak_index_path
+#   The path where the flatpak index resides
 # @param pulpcore_https_vhost
 #   The name of the Apache https vhost for Pulpcore
 # @param cname
@@ -16,6 +18,7 @@ class foreman_proxy_content::container (
   String $location_prefix = '/pulpcore_registry',
   String $registry_v1_path = '/v1/',
   String $registry_v2_path = '/v2/',
+  String $flatpak_index_path = '/index/',
   String $pulpcore_https_vhost = 'pulpcore-https',
   Stdlib::Fqdn $cname = $facts['networking']['fqdn'],
 ) {
@@ -36,6 +39,10 @@ class foreman_proxy_content::container (
       {
         'path' => $registry_v2_path,
         'url'  => "${foreman_proxy::real_registered_proxy_url}/container_gateway${registry_v2_path}",
+      },
+      {
+        'path' => $flatpak_index_path,
+        'url'  => "${foreman_proxy::real_registered_proxy_url}/container_gateway${flatpak_index_path}",
       },
     ],
   }

--- a/spec/classes/foreman_proxy_content__container_spec.rb
+++ b/spec/classes/foreman_proxy_content__container_spec.rb
@@ -23,8 +23,10 @@ describe 'foreman_proxy_content::container' do
             .with_content(%r{^\s+</Location>$})
             .with_content(%r{^\s+ProxyPass /v1/ https://foo\.example\.com:8443/container_gateway/v1/$})
             .with_content(%r{^\s+ProxyPass /v2/ https://foo\.example\.com:8443/container_gateway/v2/$})
+            .with_content(%r{^\s+ProxyPass /index/ https://foo\.example\.com:8443/container_gateway/index/$})
             .with_content(%r{^\s+ProxyPassReverse /v1/ https://foo\.example\.com:8443/container_gateway/v1/$})
             .with_content(%r{^\s+ProxyPassReverse /v2/ https://foo\.example\.com:8443/container_gateway/v2/$})
+            .with_content(%r{^\s+ProxyPassReverse /index/ https://foo\.example\.com:8443/container_gateway/index/$})
         end
       end
 
@@ -34,6 +36,7 @@ describe 'foreman_proxy_content::container' do
             location_prefix: '/other_pulpcore_registry',
             registry_v1_path: '/vr1/',
             registry_v2_path: '/vr2/',
+            flatpak_index_path: '/index/',
             pulpcore_https_vhost: 'rhsm-pulpcore-reverse-proxy-443',
             cname: 'anoTHeR.example.COM',
           }
@@ -50,8 +53,10 @@ describe 'foreman_proxy_content::container' do
             .with_content(%r{^\s+</Location>$})
             .with_content(%r{^\s+ProxyPass /vr1/ https://foo\.example\.com:8443/container_gateway/vr1/$})
             .with_content(%r{^\s+ProxyPass /vr2/ https://foo\.example\.com:8443/container_gateway/vr2/$})
+            .with_content(%r{^\s+ProxyPass /index/ https://foo\.example\.com:8443/container_gateway/index/$})
             .with_content(%r{^\s+ProxyPassReverse /vr1/ https://foo\.example\.com:8443/container_gateway/vr1/$})
             .with_content(%r{^\s+ProxyPassReverse /vr2/ https://foo\.example\.com:8443/container_gateway/vr2/$})
+            .with_content(%r{^\s+ProxyPassReverse /index/ https://foo\.example\.com:8443/container_gateway/index/$})
         end
       end
     end


### PR DESCRIPTION
Allows the container gateway to serve the flatpak index at /index/static.

Pairs with https://github.com/Katello/smart_proxy_container_gateway/pull/54