### PR TITLE
Fixes #39119 - Support generating registration command via REST API in isolated networks managed by external capsules

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,6 +127,7 @@ class foreman_proxy_content (
 
   $insights_path = '/redhat_access'
   $lightspeed_path = '/api/lightspeed'
+  $registration_commands_path = '/api/registration_commands'
 
   include certs::foreman_proxy
   Class['certs::foreman_proxy'] ~> Service['foreman-proxy']
@@ -240,9 +241,10 @@ class foreman_proxy_content (
     foreman_proxy_content::reverse_proxy { $apache_https_vhost:
       docroot      => $pulpcore::apache_docroot,
       path_url_map => {
-        $rhsm_path       => "${proxy_foreman_url}${rhsm_path}",
-        $insights_path   => "${proxy_foreman_url}${insights_path}",
-        $lightspeed_path => "${proxy_foreman_url}${lightspeed_path}",
+        $rhsm_path                  => "${proxy_foreman_url}${rhsm_path}",
+        $insights_path              => "${proxy_foreman_url}${insights_path}",
+        $lightspeed_path            => "${proxy_foreman_url}${lightspeed_path}",
+        $registration_commands_path => "${proxy_foreman_url}${registration_commands_path}",
       },
       port         => $rhsm_port,
       priority     => '10',

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -207,6 +207,7 @@ describe 'foreman_proxy_content' do
               '/rhsm' => 'h2://foo.example.com/rhsm',
               '/redhat_access' => 'h2://foo.example.com/redhat_access',
               '/api/lightspeed' => 'h2://foo.example.com/api/lightspeed',
+              '/api/registration_commands' => 'h2://foo.example.com/api/registration_commands',
             })
             .with(port: 443)
             .with(priority: '10')


### PR DESCRIPTION
To be able to generate the registration command for hosts in an isolated network.

**Before**
```
$ curl -k -X POST "https://capsule.redhat.com/api/registration_commands" \
  --user "userid:password" \
  -H "Content-Type: application/json" \
  -d '{
    "registration_command": {
      "activation_keys": ["AK1"],
      "insecure": false
    }
  }'
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
</body></html>
```
**Capsule**

Apply this fix in /usr/share/foreman-installer/modules/foreman_proxy_content

`foreman-installer -l info`

**After**
```
$ curl -k -X POST "https://capsule.redhat.com/api/registration_commands" \
  --user "userid:password" \
  -H "Content-Type: application/json" \
  -d '{
    "registration_command": {
      "activation_keys": ["AK1"],
      "insecure": false
    }
  }'
{"registration_command":"set -o pipefail \u0026\u0026 curl --silent --show-error   'https://capsule.redhat.com/register?activation_keys=AK1' --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjozLCJpYXQiOjE3NzIxMzM5NjksImp0aSI6IjYxOTRkMmJjNjY2Mjk0YjQ5YjY4ODFkNTU2YjE3MTRkOWYxOWYyM2VjZjdkNDkwZTc3ZmUyNzg5OWI4MjAyNjEiLCJleHAiOjE3NzIxNDgzNjksInNjb3BlIjoicmVnaXN0cmF0aW9uI2dsb2JhbCByZWdpc3RyYXRpb24jaG9zdCJ9.7iRQLub-VrLOfGDPxJaHURWVGXp5hd6ksE3WMzLamIw' | bash"}
```